### PR TITLE
Lift RgbaF.rgb swizzle handling to _rtsl with _is_lvalue propagation

### DIFF
--- a/metashade/_rtsl/dtypes.py
+++ b/metashade/_rtsl/dtypes.py
@@ -317,4 +317,27 @@ class RgbF:
     pass
 
 class RgbaF:
-    pass
+    def __getattr__(self, name):
+        if name == 'rgb':
+            # Get RgbF from the same module as the concrete class
+            RgbF_cls = getattr(sys.modules[self.__class__.__module__], 'RgbF')
+            result = self._sh._instantiate_dtype(
+                RgbF_cls,
+                '.'.join((str(self), name))
+            )
+            if self._is_lvalue:
+                result._is_lvalue = True
+            return result
+        else:
+            return super().__getattr__(name)
+
+    def __setattr__(self, name, value):
+        if name == 'rgb':
+            RgbF_cls = getattr(sys.modules[self.__class__.__module__], 'RgbF')
+            lvalue = self._sh._instantiate_dtype(
+                RgbF_cls,
+                '.'.join((str(self), name))
+            )
+            lvalue._assign(value)
+        else:
+            super().__setattr__(name, value)

--- a/metashade/glsl/dtypes.py
+++ b/metashade/glsl/dtypes.py
@@ -120,22 +120,3 @@ class RgbaF(rtsl.RgbaF, Float4):
             raise RuntimeError('"rgb" must be convertible to RgbF')
 
         super().__init__(_ = _, xyz = rgb, w = a)
-
-    def __getattr__(self, name):
-        if name == 'rgb':
-            return self._sh._instantiate_dtype(
-                RgbF,
-                '.'.join((str(self), name))
-            )
-        else:
-            return super().__getattr__(name)
-
-    def __setattr__(self, name, value):
-        if name == 'rgb':
-            lvalue = self._sh._instantiate_dtype(
-                RgbF,
-                '.'.join((str(self), name))
-            )
-            lvalue._assign(value)
-        else:
-            super().__setattr__(name, value)

--- a/metashade/hlsl/sm6/dtypes.py
+++ b/metashade/hlsl/sm6/dtypes.py
@@ -231,25 +231,3 @@ class RgbaF(rtsl.RgbaF, Float4):
             raise RuntimeError('"rgb" must be convertible to RgbF')
 
         super().__init__(_ = _, xyz = rgb, w = a)
-
-    def __getattr__(self, name):
-        if name == 'rgb':
-            result = self._sh._instantiate_dtype(
-                RgbF,
-                '.'.join((str(self), name))
-            )
-            if self._is_lvalue:
-                result._is_lvalue = True
-            return result
-        else:
-            return super().__getattr__(name)
-
-    def __setattr__(self, name, value):
-        if name == 'rgb':
-            lvalue = self._sh._instantiate_dtype(
-                RgbF,
-                '.'.join((str(self), name))
-            )
-            lvalue._assign(value)
-        else:
-            super().__setattr__(name, value)

--- a/metashade/hlsl/sm6/dtypes.py
+++ b/metashade/hlsl/sm6/dtypes.py
@@ -234,10 +234,13 @@ class RgbaF(rtsl.RgbaF, Float4):
 
     def __getattr__(self, name):
         if name == 'rgb':
-            return self._sh._instantiate_dtype(
+            result = self._sh._instantiate_dtype(
                 RgbF,
                 '.'.join((str(self), name))
             )
+            if self._is_lvalue:
+                result._is_lvalue = True
+            return result
         else:
             return super().__getattr__(name)
 

--- a/tests/ref/test_rgba_rgb_augmented.glsl
+++ b/tests/ref/test_rgba_rgb_augmented.glsl
@@ -1,0 +1,12 @@
+#version 450
+vec4 rgba_rgb_augmented(vec4 rgba, vec3 rgb)
+{
+	rgba.rgb += rgb;
+	rgba.rgb = rgba.rgb;
+	return rgba;
+}
+
+void main()
+{
+}
+

--- a/tests/ref/test_rgba_rgb_augmented.hlsl
+++ b/tests/ref/test_rgba_rgb_augmented.hlsl
@@ -1,0 +1,11 @@
+float4 rgba_rgb_augmented(float4 rgba, float3 rgb)
+{
+	rgba.rgb += rgb;
+	rgba.rgb = rgba.rgb;
+	return rgba;
+}
+
+void main()
+{
+}
+

--- a/tests/test_swizzling.py
+++ b/tests/test_swizzling.py
@@ -60,3 +60,14 @@ class TestSwizzling:
                 sh.res2 = ((sh.v1 * sh.v2) + sh.v1).w
 
                 sh.return_(sh.res1 + sh.res2)
+
+    @ctx_cls_hg
+    def test_rgba_rgb_augmented(self, ctx_cls):
+        """Test augmented assignment on rgba.rgb swizzle (_is_lvalue propagation)."""
+        with ctx_cls(dummy_entry_point = True) as sh:
+            with sh.function('rgba_rgb_augmented', sh.RgbaF)(
+                rgba = sh.RgbaF, rgb = sh.RgbF
+            ):
+                # This requires _is_lvalue to be propagated from rgba to rgba.rgb
+                sh.rgba.rgb += sh.rgb
+                sh.return_(sh.rgba)


### PR DESCRIPTION
## Problem

The `RgbaF.__getattr__` method had a special case for the `.rgb` swizzle but wasn't propagating the `_is_lvalue` flag from the parent object. This caused augmented assignments like `rgba.rgb += rgb` to fail with "Can't modify an rvalue".

Additionally, the `__getattr__` and `__setattr__` implementations were duplicated between HLSL and GLSL.

## Solution

- Lifted `RgbaF.__getattr__` and `__setattr__` to `_rtsl/dtypes.py` base class
- Added `_is_lvalue` propagation when accessing the `.rgb` swizzle
- Removed duplicate implementations from HLSL (`hlsl/sm6/dtypes.py`) and GLSL (`glsl/dtypes.py`)

## Test

Added `test_rgba_rgb_augmented` to verify augmented assignment on `rgba.rgb` swizzle works correctly:

```python
sh.rgba.rgb += sh.rgb  # Now generates: rgba.rgb += rgb;
```

## Why `_is_lvalue` is needed

For swizzled accessors like `rgba.rgb`:
- `_name = None` (not a named variable)
- `_expression = "rgba.rgb"` (expression string)
- Can still be lvalues if parent is lvalue!

So `_is_lvalue` is necessary because checking `_name is not None` doesn't work for swizzle chains.