### PR TITLE
Add API to create struct types without emission

### DIFF
--- a/metashade/targets/_clike/generator.py
+++ b/metashade/targets/_clike/generator.py
@@ -23,8 +23,8 @@ class Generator(base.Generator):
     def function(self, name : str, return_type = None):
         return context.FunctionDecl(self, name, return_type)
 
-    def struct(self, name):
-        return struct.StructDef(self, name)
+    def struct(self, name, emit=True):
+        return struct.StructDef(self, name, emit=emit)
     
     def array(self, element_type, dims):
         element_type = element_type._get_dtype()

--- a/metashade/targets/_clike/struct.py
+++ b/metashade/targets/_clike/struct.py
@@ -70,7 +70,7 @@ class Struct(BaseType, StructBase):
         if not self._set_member(name, value):
             super().__setattr__(name, value)
 
-def define_struct(sh, name, member_defs):
+def define_struct(sh, name, member_defs, emit=True):
     struct_type = type(
         name,
         (Struct,),
@@ -80,6 +80,9 @@ def define_struct(sh, name, member_defs):
         }
     )
     sh._set_global(name, struct_type)
+
+    if not emit:
+        return
 
     sh._emit(f'struct {name}\n{{\n')
     sh._push_indent()
@@ -93,9 +96,10 @@ def define_struct(sh, name, member_defs):
     sh._emit('};\n\n')
 
 class StructDef:
-    def __init__(self, sh, name):
+    def __init__(self, sh, name, emit=True):
         self._sh = sh
         self._name = name
+        self._emit = emit
 
     def __call__(self, **kwargs):
         define_struct(
@@ -104,6 +108,7 @@ class StructDef:
             {
                 name : StructMemberDef(dtype_factory._get_dtype())
                 for name, dtype_factory in kwargs.items()
-            }
+            },
+            emit=self._emit
         )
 

--- a/tests/ref/test_struct_emission.glsl
+++ b/tests/ref/test_struct_emission.glsl
@@ -1,0 +1,12 @@
+#version 450
+struct TestStruct
+{
+	float a;
+	vec3 b;
+	vec2 c;
+};
+
+void main()
+{
+}
+

--- a/tests/ref/test_struct_emission.hlsl
+++ b/tests/ref/test_struct_emission.hlsl
@@ -1,0 +1,11 @@
+struct TestStruct
+{
+	float a;
+	float3 b;
+	float2 c;
+};
+
+void main()
+{
+}
+

--- a/tests/ref/test_struct_emit_false.glsl
+++ b/tests/ref/test_struct_emit_false.glsl
@@ -1,0 +1,13 @@
+#version 450
+struct ExternStruct { vec3 response; vec3 throughput; };
+
+void useStruct(ExternStruct s)
+{
+	vec3 result = s.response + s.throughput;
+	return;
+}
+
+void main()
+{
+}
+

--- a/tests/ref/test_struct_emit_false.hlsl
+++ b/tests/ref/test_struct_emit_false.hlsl
@@ -1,0 +1,12 @@
+struct ExternStruct { float3 response; float3 throughput; };
+
+void useStruct(ExternStruct s)
+{
+	float3 result = s.response + s.throughput;
+	return;
+}
+
+void main()
+{
+}
+

--- a/tests/ref/test_struct_emit_false_in_function.glsl
+++ b/tests/ref/test_struct_emit_false_in_function.glsl
@@ -1,0 +1,9 @@
+#version 450
+struct BSDF { vec3 response; vec3 throughput; };
+
+BSDF getBsdf();
+
+void main()
+{
+}
+

--- a/tests/ref/test_struct_emit_false_in_function.hlsl
+++ b/tests/ref/test_struct_emit_false_in_function.hlsl
@@ -1,0 +1,8 @@
+struct BSDF { float3 response; float3 throughput; };
+
+BSDF getBsdf();
+
+void main()
+{
+}
+

--- a/tests/ref/test_struct_registration.glsl
+++ b/tests/ref/test_struct_registration.glsl
@@ -1,0 +1,11 @@
+#version 450
+struct MyStruct
+{
+	float x;
+	float y;
+};
+
+void main()
+{
+}
+

--- a/tests/ref/test_struct_registration.hlsl
+++ b/tests/ref/test_struct_registration.hlsl
@@ -1,0 +1,10 @@
+struct MyStruct
+{
+	float x;
+	float y;
+};
+
+void main()
+{
+}
+

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Pavlo Penenko
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for struct definition and acquisition.
+"""
+
+from __future__ import annotations
+
+import pytest
+from metashade.util.testing import ctx_cls_hg, HlslTestContext
+
+
+class TestStructDefinition:
+    """Tests for defining structs with sh.struct()."""
+
+    @ctx_cls_hg
+    def test_struct_emission(self, ctx_cls):
+        """Test that sh.struct() emits correct code and compiles."""
+        ctx = ctx_cls(dummy_entry_point=True)
+        with ctx as sh:
+            sh.struct('TestStruct')(
+                a=sh.Float,
+                b=sh.Float3,
+                c=sh.Float2
+            )
+
+    @ctx_cls_hg
+    def test_struct_registration(self, ctx_cls):
+        """Test that struct type is registered on generator."""
+        ctx = ctx_cls(dummy_entry_point=True)
+        with ctx as sh:
+            sh.struct('MyStruct')(x=sh.Float, y=sh.Float)
+            
+            # Struct type should be accessible
+            assert hasattr(sh, 'MyStruct')
+
+    @ctx_cls_hg
+    def test_struct_emit_false(self, ctx_cls):
+        """Test that emit=False registers type without emitting code.
+        
+        Writes struct definition directly to file first, then acquires
+        without emission, then uses it in a function.
+        """
+        ctx = ctx_cls(dummy_entry_point=True)
+        with ctx as sh:
+            # Write struct definition directly (simulates external definition)
+            if isinstance(ctx, HlslTestContext):
+                sh._emit('struct ExternStruct { float3 response; float3 throughput; };\n\n')
+            else:
+                sh._emit('struct ExternStruct { vec3 response; vec3 throughput; };\n\n')
+            
+            # Acquire the struct without emitting code
+            sh.struct('ExternStruct', emit=False)(
+                response=sh.Float3,
+                throughput=sh.Float3
+            )
+            
+            # Type should be registered
+            assert hasattr(sh, 'ExternStruct')
+            
+            # Use the acquired struct in a function
+            with sh.function('useStruct')(s=sh.ExternStruct):
+                sh.result = sh.s.response + sh.s.throughput
+                sh.return_()
+
+    @ctx_cls_hg
+    def test_struct_emit_false_in_function(self, ctx_cls):
+        """Test that acquired struct can be used as function return type."""
+        ctx = ctx_cls(dummy_entry_point=True)
+        with ctx as sh:
+            # Write struct definition directly
+            if isinstance(ctx, HlslTestContext):
+                sh._emit('struct BSDF { float3 response; float3 throughput; };\n\n')
+            else:
+                sh._emit('struct BSDF { vec3 response; vec3 throughput; };\n\n')
+            
+            # Acquire struct without emission
+            sh.struct('BSDF', emit=False)(
+                response=sh.Float3,
+                throughput=sh.Float3
+            )
+            
+            # Declare a function that returns the struct
+            sh.function('getBsdf', sh.BSDF)().declare()


### PR DESCRIPTION
Add emit=True parameter to sh.struct(name, emit=True):
- sh.struct('Name')(fields) - emits struct definition
- sh.struct('Name', emit=False)(fields) - registers type only

This enables acquiring external struct types (like MaterialX BSDF) that are defined elsewhere, without emitting duplicate definitions.

Also adds test_struct.py with 8 tests (4 tests × HLSL/GLSL):
- test_struct_emission - verifies code emission
- test_struct_registration - verifies type registration
- test_struct_emit_false - writes extern struct, acquires without emit
- test_struct_emit_false_in_function - uses acquired struct as return type