### PR TITLE
Add emit parameter to Function declare() API

### DIFF
--- a/metashade/mtlx/mtlx_reflection.py
+++ b/metashade/mtlx/mtlx_reflection.py
@@ -28,12 +28,16 @@ graph-based implementations defined in MaterialX XML.
 from metashade.mtlx.dtypes import mtlx_to_metashade_dtype
 from metashade.targets._clike.context import FunctionDecl
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from metashade.targets._clike.context import Function
+
 def _sanitize_identifier(name: str) -> str:
     """Sanitize an identifier to avoid reserved words.
     
-    MaterialX commonly uses 'out' as an output parameter name, which is
-    a reserved word in GLSL/HLSL. This function appends an underscore
-    to such identifiers.
+    MaterialX commonly uses reserved keywords like 'in', 'out', and 'inout'
+    as parameter names, which are reserved in GLSL/HLSL. This function
+    appends an underscore to such identifiers.
     """
     reserved = {'out', 'in', 'inout'}
     if name in reserved:
@@ -102,7 +106,7 @@ def acquire_function(sh, impl):
     return getattr(sh, func_attr)
 
 
-def acquire_stdlib(sh, doc, target: str) -> dict:
+def acquire_stdlib(sh, doc, target: str) -> dict[str, 'Function']:
     """
     Acquire all MaterialX source-code functions into the generator.
     

--- a/metashade/targets/_clike/context.py
+++ b/metashade/targets/_clike/context.py
@@ -104,10 +104,11 @@ class FunctionDecl:
 
         self._sh._emit(')')
 
-    def declare(self):
+    def declare(self, emit=True):
         '''Emit a function prototype.'''
-        self._emit_signature()
-        self._sh._emit(';\n\n')
+        if emit:
+            self._emit_signature()
+            self._sh._emit(';\n\n')
         
         # Register the callable in the generator
         self._sh._set_global(

--- a/tests/ref/test_function_declare_no_emit.glsl
+++ b/tests/ref/test_function_declare_no_emit.glsl
@@ -1,0 +1,17 @@
+#version 450
+layout (set = 0, binding = 0) uniform cb
+{
+	vec4 g_f4A;
+	vec4 g_f4B;
+	vec3 g_f3C;
+};
+
+vec4 externalAdd(vec4 a, vec4 b) { return a + b; }
+
+layout(location = 0) out vec4 out_f4Color;
+void main()
+{
+	vec4 c = externalAdd(g_f4A, g_f4B);
+	out_f4Color = c;
+}
+

--- a/tests/ref/test_function_declare_no_emit.hlsl
+++ b/tests/ref/test_function_declare_no_emit.hlsl
@@ -1,0 +1,23 @@
+[[vk::binding(0, 0)]]
+cbuffer cb : register(b0)
+{
+	float4 g_f4A;
+	float4 g_f4B;
+	float3 g_f3C;
+};
+
+float4 externalAdd(float4 a, float4 b) { return a + b; }
+
+struct PsOut
+{
+	float4 color : SV_TARGET;
+};
+
+PsOut main()
+{
+	float4 c = externalAdd(g_f4A, g_f4B);
+	PsOut result;
+	result.color = c;
+	return result;
+}
+


### PR DESCRIPTION
This PR adds an `emit` parameter to `FunctionDecl.declare()`, mirroring the recent changes to the Struct API.

### Changes
- Added `emit=True` parameter to `FunctionDecl.declare()`. When `emit=False`, the function is registered on the generator without emitting a prototype.
- Refactored `acquire_function()` in `mtlx_reflection.py` to use `FunctionDecl` API instead of manual `Function` object construction. This unifies the code path and removes dependencies on internal classes.
- Added `test_function_declare_no_emit` to verify `emit=False` behavior.

### Purpose
This feature allows acquiring external functions (e.g. from MaterialX source code or included files) and registering them for use in Metashade without generating duplicate prototypes.