### PR TITLE
Improve struct tests with robust integration testing

### DIFF
--- a/tests/ref/test_struct_emit_false.glsl
+++ b/tests/ref/test_struct_emit_false.glsl
@@ -1,13 +1,25 @@
 #version 450
+layout (set = 0, binding = 0) uniform cb
+{
+	vec3 g_f3A;
+	vec3 g_f3B;
+};
+
 struct ExternStruct { vec3 response; vec3 throughput; };
 
-void useStruct(ExternStruct s)
+ExternStruct computeStruct(vec3 a, vec3 b)
 {
-	vec3 result = s.response + s.throughput;
-	return;
+	ExternStruct result;
+	result.response = a;
+	result.throughput = b;
+	return result;
 }
 
+layout(location = 0) out vec4 out_Color;
 void main()
 {
+	ExternStruct s = computeStruct(g_f3A, g_f3B);
+	vec4 final_color = vec4(s.response + s.throughput, 1.0);
+	out_Color = final_color;
 }
 

--- a/tests/ref/test_struct_emit_false.glsl
+++ b/tests/ref/test_struct_emit_false.glsl
@@ -17,11 +17,11 @@ ExternStruct computeStruct(vec3 a, vec3 b)
 	return result;
 }
 
-layout(location = 0) out vec4 out_Color;
+layout(location = 0) out vec4 out_f4Color;
 void main()
 {
 	ExternStruct s = computeStruct(g_f3A, g_f3B);
 	vec4 final_color = vec4(s.response + s.throughput, 1.0);
-	out_Color = final_color;
+	out_f4Color = final_color;
 }
 

--- a/tests/ref/test_struct_emit_false.glsl
+++ b/tests/ref/test_struct_emit_false.glsl
@@ -5,10 +5,12 @@ layout (set = 0, binding = 0) uniform cb
 	vec3 g_f3B;
 };
 
+// The struct defined in the target language
 struct ExternStruct { vec3 response; vec3 throughput; };
 
 ExternStruct computeStruct(vec3 a, vec3 b)
 {
+	// Now, use the struct
 	ExternStruct result;
 	result.response = a;
 	result.throughput = b;

--- a/tests/ref/test_struct_emit_false.hlsl
+++ b/tests/ref/test_struct_emit_false.hlsl
@@ -1,12 +1,31 @@
+[[vk::binding(0, 0)]]
+cbuffer cb : register(b0)
+{
+	float3 g_f3A;
+	float3 g_f3B;
+};
+
 struct ExternStruct { float3 response; float3 throughput; };
 
-void useStruct(ExternStruct s)
+ExternStruct computeStruct(float3 a, float3 b)
 {
-	float3 result = s.response + s.throughput;
-	return;
+	ExternStruct result;
+	result.response = a;
+	result.throughput = b;
+	return result;
 }
 
-void main()
+struct PsOut
 {
+	float4 color : SV_TARGET;
+};
+
+PsOut main()
+{
+	ExternStruct s = computeStruct(g_f3A, g_f3B);
+	float4 final_color = float4(s.response + s.throughput, 1.0);
+	PsOut out_struct;
+	out_struct.color = final_color;
+	return out_struct;
 }
 

--- a/tests/ref/test_struct_emit_false.hlsl
+++ b/tests/ref/test_struct_emit_false.hlsl
@@ -5,10 +5,12 @@ cbuffer cb : register(b0)
 	float3 g_f3B;
 };
 
+// The struct defined in the target language
 struct ExternStruct { float3 response; float3 throughput; };
 
 ExternStruct computeStruct(float3 a, float3 b)
 {
+	// Now, use the struct
 	ExternStruct result;
 	result.response = a;
 	result.throughput = b;

--- a/tests/ref/test_struct_emit_false_in_function.glsl
+++ b/tests/ref/test_struct_emit_false_in_function.glsl
@@ -1,9 +1,25 @@
 #version 450
+layout (set = 0, binding = 0) uniform cb
+{
+	vec3 g_f3A;
+	vec3 g_f3B;
+};
+
 struct BSDF { vec3 response; vec3 throughput; };
 
-BSDF getBsdf();
+BSDF getBsdf(vec3 r, vec3 t)
+{
+	BSDF b;
+	b.response = r;
+	b.throughput = t;
+	return b;
+}
 
+layout(location = 0) out vec4 out_Color;
 void main()
 {
+	BSDF bsdf = getBsdf(g_f3A, g_f3B);
+	vec4 final = vec4(bsdf.response * bsdf.throughput, 1.0);
+	out_Color = final;
 }
 

--- a/tests/ref/test_struct_emit_false_in_function.glsl
+++ b/tests/ref/test_struct_emit_false_in_function.glsl
@@ -5,10 +5,12 @@ layout (set = 0, binding = 0) uniform cb
 	vec3 g_f3B;
 };
 
+// The struct defined in the target language
 struct BSDF { vec3 response; vec3 throughput; };
 
 BSDF getBsdf(vec3 r, vec3 t)
 {
+	// Now, use the struct
 	BSDF b;
 	b.response = r;
 	b.throughput = t;

--- a/tests/ref/test_struct_emit_false_in_function.glsl
+++ b/tests/ref/test_struct_emit_false_in_function.glsl
@@ -17,11 +17,11 @@ BSDF getBsdf(vec3 r, vec3 t)
 	return b;
 }
 
-layout(location = 0) out vec4 out_Color;
+layout(location = 0) out vec4 out_f4Color;
 void main()
 {
 	BSDF bsdf = getBsdf(g_f3A, g_f3B);
 	vec4 final = vec4(bsdf.response * bsdf.throughput, 1.0);
-	out_Color = final;
+	out_f4Color = final;
 }
 

--- a/tests/ref/test_struct_emit_false_in_function.hlsl
+++ b/tests/ref/test_struct_emit_false_in_function.hlsl
@@ -1,8 +1,31 @@
+[[vk::binding(0, 0)]]
+cbuffer cb : register(b0)
+{
+	float3 g_f3A;
+	float3 g_f3B;
+};
+
 struct BSDF { float3 response; float3 throughput; };
 
-BSDF getBsdf();
-
-void main()
+BSDF getBsdf(float3 r, float3 t)
 {
+	BSDF b;
+	b.response = r;
+	b.throughput = t;
+	return b;
+}
+
+struct PsOut
+{
+	float4 color : SV_TARGET;
+};
+
+PsOut main()
+{
+	BSDF bsdf = getBsdf(g_f3A, g_f3B);
+	float4 final = float4(bsdf.response * bsdf.throughput, 1.0);
+	PsOut out_struct;
+	out_struct.color = final;
+	return out_struct;
 }
 

--- a/tests/ref/test_struct_emit_false_in_function.hlsl
+++ b/tests/ref/test_struct_emit_false_in_function.hlsl
@@ -5,10 +5,12 @@ cbuffer cb : register(b0)
 	float3 g_f3B;
 };
 
+// The struct defined in the target language
 struct BSDF { float3 response; float3 throughput; };
 
 BSDF getBsdf(float3 r, float3 t)
 {
+	// Now, use the struct
 	BSDF b;
 	b.response = r;
 	b.throughput = t;

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -64,7 +64,7 @@ class TestStructDefinition:
                 PsOut.SV_Target('color', out_type)
             return sh.entry_point(ctx._entry_point_name, sh.PsOut)()
         else:
-            sh.out_Color = sh.stage_output(out_type, location=0)
+            sh.out_f4Color = sh.stage_output(out_type, location = 0)
             return sh.entry_point(ctx._entry_point_name)()
 
     @ctx_cls_hg
@@ -74,7 +74,7 @@ class TestStructDefinition:
         Writes struct definition directly to file first, then acquires
         without emission, then uses it in a function.
         """
-        ctx = ctx_cls(dummy_entry_point=False)
+        ctx = ctx_cls(dummy_entry_point = False)
         with ctx as sh:
             self._generate_test_uniforms(sh)
 
@@ -86,9 +86,9 @@ class TestStructDefinition:
                 sh._emit('struct ExternStruct { vec3 response; vec3 throughput; };\n\n')
             
             # Acquire the struct without emitting code
-            sh.struct('ExternStruct', emit=False)(
-                response=sh.Float3,
-                throughput=sh.Float3
+            sh.struct('ExternStruct', emit = False)(
+                response = sh.Float3,
+                throughput = sh.Float3
             )
             
             # Type should be registered
@@ -96,7 +96,7 @@ class TestStructDefinition:
             
             # Use the acquired struct in a function
             with sh.function('computeStruct', sh.ExternStruct)(
-                a=sh.Float3, b=sh.Float3
+                a = sh.Float3, b = sh.Float3
             ):
                 sh // 'Now, use the struct'
                 sh.result = sh.ExternStruct()
@@ -106,11 +106,11 @@ class TestStructDefinition:
 
             # Use in main shader to force compilation
             with self._generate_ps_main_decl(sh, ctx, sh.Float4):
-                sh.s = sh.computeStruct(a=sh.g_f3A, b=sh.g_f3B)
+                sh.s = sh.computeStruct(a = sh.g_f3A, b = sh.g_f3B)
                 # Output flattened result
                 sh.final_color = sh.Float4(
-                    xyz=sh.s.response + sh.s.throughput, 
-                    w=1.0
+                    xyz = sh.s.response + sh.s.throughput, 
+                    w = 1.0
                 )
                 
                 if isinstance(ctx, HlslTestContext):
@@ -118,12 +118,12 @@ class TestStructDefinition:
                     sh.out_struct.color = sh.final_color
                     sh.return_(sh.out_struct)
                 else:
-                    sh.out_Color = sh.final_color
+                    sh.out_f4Color = sh.final_color
 
     @ctx_cls_hg
     def test_struct_emit_false_in_function(self, ctx_cls):
         """Test that acquired struct can be used as function return type."""
-        ctx = ctx_cls(dummy_entry_point=False)
+        ctx = ctx_cls(dummy_entry_point = False)
         with ctx as sh:
             self._generate_test_uniforms(sh)
 
@@ -135,15 +135,15 @@ class TestStructDefinition:
                 sh._emit('struct BSDF { vec3 response; vec3 throughput; };\n\n')
             
             # Acquire struct without emission
-            sh.struct('BSDF', emit=False)(
-                response=sh.Float3,
-                throughput=sh.Float3
+            sh.struct('BSDF', emit = False)(
+                response = sh.Float3,
+                throughput = sh.Float3
             )
             
             # Define a function that returns the struct using Metashade
             # This verifies the struct type works in function signatures and bodies
             with sh.function('getBsdf', sh.BSDF)(
-                r=sh.Float3, t=sh.Float3
+                r = sh.Float3, t = sh.Float3
             ):
                 sh // 'Now, use the struct'
                 sh.b = sh.BSDF()
@@ -153,11 +153,11 @@ class TestStructDefinition:
 
             # Use in main shader
             with self._generate_ps_main_decl(sh, ctx, sh.Float4):
-                sh.bsdf = sh.getBsdf(r=sh.g_f3A, t=sh.g_f3B)
+                sh.bsdf = sh.getBsdf(r = sh.g_f3A, t = sh.g_f3B)
                 
                 sh.final = sh.Float4(
-                    xyz=sh.bsdf.response * sh.bsdf.throughput,
-                    w=1.0
+                    xyz = sh.bsdf.response * sh.bsdf.throughput,
+                    w = 1.0
                 )
 
                 if isinstance(ctx, HlslTestContext):
@@ -165,4 +165,4 @@ class TestStructDefinition:
                     sh.out_struct.color = sh.final
                     sh.return_(sh.out_struct)
                 else:
-                    sh.out_Color = sh.final
+                    sh.out_f4Color = sh.final


### PR DESCRIPTION
This PR enhances `tests/test_struct.py` to provide better coverage for the Struct API.

### Improvements
- **Integration Tests**: Tests now hook into the shader entry point (VS/PS) to guarantee full compilation and linking.
- **Runtime Verification**: Tests verify that acquired structs work correctly in the full shader pipeline (inputs -> computation -> output).
- **External Struct Simulation**: Tests simulate external struct definitions via raw `_emit` and acquire them using `emit=False` (which is already in `main`).
- **Compatibility**: Tests are compatible with `main` branch (avoiding unmerged function features).

This addresses feedback to ensure struct tests are as robust as function tests.