### PR TITLE
chore: bump version to 0.6.0a1 and add manual PyPI publish script

### DIFF
--- a/metashade/__init__.py
+++ b/metashade/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.1"
+__version__ = "0.6.0a1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metashade"
-version = "0.5.1"
+version = "0.6.0a1"
 description = "An experimental Python-based GPU shading embedded domain-specific language (EDSL)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/publish_manual.sh
+++ b/scripts/publish_manual.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Cleaning previous builds..."
+rm -rf dist/ build/ *.egg-info
+
+echo "Upgrading build tools..."
+python3 -m pip install --upgrade pip build twine
+
+echo "Building source distribution and wheel..."
+python3 -m build
+
+echo "Uploading to PyPI..."
+# This will prompt for a PyPI API token
+python3 -m twine upload dist/*
+
+echo "Alpha release 0.6.0a1 published successfully!"

--- a/scripts/publish_manual.sh
+++ b/scripts/publish_manual.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure we're running from the repository root
+cd "$(git rev-parse --show-toplevel)"
+
 echo "Cleaning previous builds..."
 rm -rf dist/ build/ *.egg-info
 
@@ -11,7 +14,9 @@ echo "Building source distribution and wheel..."
 python3 -m build
 
 echo "Uploading to PyPI..."
-# This will prompt for a PyPI API token
+# Twine will prompt for your PyPI username and password (use __token__
+# as the username and your PyPI API token as the password, or set
+# TWINE_USERNAME/TWINE_PASSWORD environment variables).
 python3 -m twine upload dist/*
 
-echo "Alpha release 0.6.0a1 published successfully!"
+echo "Release published successfully!"


### PR DESCRIPTION
Prepares for the first alpha release toward v0.6.0.

## Changes
- **Version bump:** `0.5.1` → `0.6.0a1` in `pyproject.toml` and `metashade/__init__.py`
- **Publish script:** `scripts/publish_manual.sh` — standard build + twine upload workflow for manual PyPI releases