### PR TITLE
fix: use py on Windows in publish script

### DIFF
--- a/scripts/publish_manual.sh
+++ b/scripts/publish_manual.sh
@@ -4,19 +4,26 @@ set -e
 # Ensure we're running from the repository root
 cd "$(git rev-parse --show-toplevel)"
 
+# Use 'py' on Windows, 'python3' elsewhere
+if command -v py &> /dev/null; then
+    PYTHON=py
+else
+    PYTHON=python3
+fi
+
 echo "Cleaning previous builds..."
 rm -rf dist/ build/ *.egg-info
 
 echo "Upgrading build tools..."
-python3 -m pip install --upgrade pip build twine
+$PYTHON -m pip install --upgrade pip build twine
 
 echo "Building source distribution and wheel..."
-python3 -m build
+$PYTHON -m build
 
 echo "Uploading to PyPI..."
 # Twine will prompt for your PyPI username and password (use __token__
 # as the username and your PyPI API token as the password, or set
 # TWINE_USERNAME/TWINE_PASSWORD environment variables).
-python3 -m twine upload dist/*
+$PYTHON -m twine upload dist/*
 
 echo "Release published successfully!"


### PR DESCRIPTION
The publish script used `python3` which doesn't exist on Windows. Now detects the platform and uses `py` on Windows, `python3` elsewhere.