### PR TITLE
chore: configure PyPI trusted publishing and bump to 0.6.0a2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/metashade
+    permissions:
+      id-token: write  # MANDATORY for trusted publishing
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip build
+
+      - name: Build Source Distribution and Wheel
+        run: python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/metashade/__init__.py
+++ b/metashade/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0a1"
+__version__ = "0.6.0a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metashade"
-version = "0.6.0a1"
+version = "0.6.0a2"
 description = "An experimental Python-based GPU shading embedded domain-specific language (EDSL)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Automates PyPI releases via GitHub Actions using trusted publishing (no API tokens needed).

## Changes
- **`.github/workflows/publish.yml`**: Triggers on GitHub Release → builds sdist + wheel → publishes to PyPI via OIDC trusted publishing
- **Version bump**: `0.6.0a1` → `0.6.0a2` in `pyproject.toml` and `metashade/__init__.py`

## Setup Required
After merging, configure trusted publishing on PyPI:
1. Go to https://pypi.org/manage/project/metashade/settings/publishing/
2. Add a new publisher: owner=`metashade`, repo=`metashade`, workflow=`publish.yml`, environment=`pypi`
3. Create a GitHub Release tagged `v0.6.0a2` to trigger the first automated publish