### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/metashade/__init__.py
+++ b/metashade/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0a2"
+__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metashade"
-version = "0.6.0a2"
+version = "0.6.0"
 description = "An experimental Python-based GPU shading embedded domain-specific language (EDSL)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bump version from `0.6.0a2` to `0.6.0` for the stable release.

### Changes
- `pyproject.toml`: `version = "0.6.0"`
- `metashade/__init__.py`: `__version__ = "0.6.0"`

After merging, tag the merge commit as `v0.6.0` and publish the release.