### PR TITLE
Feature: Native Default Parameter Syntax Support for Context Managers

### DIFF
--- a/metashade/mtlx/generate.py
+++ b/metashade/mtlx/generate.py
@@ -17,7 +17,7 @@ import abc
 
 import MaterialX as mx
 from metashade.targets.glsl import frag
-from metashade.targets._rtsl.qualifiers import Direction
+from metashade.targets._rtsl.qualifiers import _Out
 
 from metashade.mtlx import dtypes
 
@@ -114,10 +114,7 @@ class GeneratorContext:
 
             # Add parameters in their original order
             for param_name, param_def in func._param_defs.items():
-                is_output = any(
-                    qualifier.direction == Direction.OUT 
-                    for qualifier in param_def.qualifiers
-                )
+                is_output = isinstance(param_def.direction, _Out)
                 param_type = dtypes.metashade_to_mtlx(param_def.dtype_factory)
                 
                 if is_output:

--- a/metashade/targets/_clike/arrays.py
+++ b/metashade/targets/_clike/arrays.py
@@ -34,9 +34,9 @@ class ArrayBase(BaseType):
         semantic = None,
         register : int = None,
         initializer = None,
-        qualifiers = None
+        qualifier = None
     ):
-        BaseType._emit_qualifiers(sh, qualifiers)
+        BaseType._emit_qualifier(sh, qualifier)
         
         sh._emit(
             '{element_type} {identifier}{dims}'.format(

--- a/metashade/targets/_clike/context.py
+++ b/metashade/targets/_clike/context.py
@@ -237,7 +237,7 @@ class Function:
 
         for param_name, param_def in self._param_defs.items():
             arg = kwargs.get(param_name)
-            if arg is None:
+            if param_name not in kwargs:
                 if param_def.default is not None:
                     arg = param_def.default
                 else:

--- a/metashade/targets/_clike/context.py
+++ b/metashade/targets/_clike/context.py
@@ -25,6 +25,7 @@ class _ParamDef(NamedTuple):
     '''
     dtype_factory: object  # Generator._DtypeFactory
     qualifiers: list  # List of ParamQualifiers
+    default: object = None
 
 class FunctionDecl:
     '''
@@ -53,6 +54,8 @@ class FunctionDecl:
         self._param_defs = {}
         
         for name, dtype_factory in param_annotations.items():
+            default = None
+
             # Check if this is an Annotated type with qualifiers
             qualifiers = []
             if typing.get_origin(dtype_factory) is typing.Annotated:
@@ -60,14 +63,16 @@ class FunctionDecl:
                 # Annotated[dtype_factory, qualifier1, qualifier2, ...]
                 typing_args = typing.get_args(dtype_factory)
                 dtype_factory = typing_args[0]
-                qualifiers = [
-                    annotation for annotation in typing_args[1:]
-                    if isinstance(annotation, ParamQualifiers)
-                ]
+                for annotation in typing_args[1:]:
+                    if isinstance(annotation, ParamQualifiers):
+                        qualifiers.append(annotation)
+                        if annotation.default is not None:
+                            default = annotation.default
             
             self._param_defs[name] = _ParamDef(
                 dtype_factory=dtype_factory,
-                qualifiers=qualifiers
+                qualifiers=qualifiers,
+                default=default
             )
 
         # Return self, so that it can be entered in a with scope
@@ -126,7 +131,10 @@ class FunctionDecl:
         if self._doc is not None:
             for line in self._doc.strip().split('\n'):
                 # Escape non-ASCII characters to \uXXXX format for safe output
-                safe_line = line.strip().encode('ascii', 'backslashreplace').decode('ascii')
+                safe_line = line.strip().encode(
+                    'ascii', 'backslashreplace'
+                ).decode('ascii')
+
                 self._sh._emit_indent()
                 self._sh._emit(f'// {safe_line}\n')
             self._sh._emit_indent()
@@ -230,9 +238,12 @@ class Function:
         for param_name, param_def in self._param_defs.items():
             arg = kwargs.get(param_name)
             if arg is None:
-                raise RuntimeError(
-                    f"Argument missing for parameter '{param_name}'"
-                )
+                if param_def.default is not None:
+                    arg = param_def.default
+                else:
+                    raise RuntimeError(
+                        f"Argument missing for parameter '{param_name}'"
+                    )
             # Get the dtype class from the factory and use it for type checking
             dtype_class = param_def.dtype_factory._get_dtype()
             ref = dtype_class._get_value_ref(arg)
@@ -242,7 +253,7 @@ class Function:
                 )
             
             arg_list.append(str(ref))
-            kwargs.pop(param_name)
+            kwargs.pop(param_name, None)
 
         if kwargs:
             unmatched_arg_names = ', '.join([

--- a/metashade/targets/_clike/context.py
+++ b/metashade/targets/_clike/context.py
@@ -17,14 +17,14 @@ import typing
 from typing import NamedTuple
 
 import metashade.targets._base.context as base
-from .._rtsl.qualifiers import ParamQualifiers
+from .._rtsl.qualifiers import _ParamDirection, _In
 
 class _ParamDef(NamedTuple):
     '''
-    Function parameter definition: dtype factory and qualifiers.
+    Function parameter definition: dtype factory and direction.
     '''
     dtype_factory: object  # Generator._DtypeFactory
-    qualifiers: list  # List of ParamQualifiers
+    direction: object = None  # _ParamDirection or None (implicit IN)
     default: object = None
 
 class FunctionDecl:
@@ -50,28 +50,25 @@ class FunctionDecl:
         return self._init_param_defs(**kwargs)
 
     def _init_param_defs(self, **param_annotations):
-        '''Parse parameter annotations to extract dtype factories and qualifiers.'''
+        '''Parse parameter annotations to extract dtype factories and direction.'''
         self._param_defs = {}
         
         for name, dtype_factory in param_annotations.items():
+            direction = None
             default = None
 
-            # Check if this is an Annotated type with qualifiers
-            qualifiers = []
             if typing.get_origin(dtype_factory) is typing.Annotated:
-                # Extract base dtype factory and qualifiers from 
-                # Annotated[dtype_factory, qualifier1, qualifier2, ...]
                 typing_args = typing.get_args(dtype_factory)
                 dtype_factory = typing_args[0]
                 for annotation in typing_args[1:]:
-                    if isinstance(annotation, ParamQualifiers):
-                        qualifiers.append(annotation)
-                        if annotation.default is not None:
+                    if isinstance(annotation, _ParamDirection):
+                        direction = annotation
+                        if isinstance(annotation, _In):
                             default = annotation.default
             
             self._param_defs[name] = _ParamDef(
                 dtype_factory=dtype_factory,
-                qualifiers=qualifiers,
+                direction=direction,
                 default=default
             )
 
@@ -104,7 +101,7 @@ class FunctionDecl:
                 self._sh,
                 name,
                 allow_init=False,
-                qualifiers=param_def.qualifiers
+                qualifier=param_def.direction
             )
 
         self._sh._emit(')')

--- a/metashade/targets/_clike/dtypes.py
+++ b/metashade/targets/_clike/dtypes.py
@@ -38,13 +38,10 @@ class BaseType(base.BaseType):
             sh._emit(f' : register({cls._format_uniform_register(register)})')
 
     @classmethod
-    def _emit_qualifiers(cls, sh, qualifiers):
-        """Helper method to emit parameter qualifiers"""
-        if qualifiers:
-            for qualifier in qualifiers:
-                qualifier_str = qualifier.direction.value
-                if qualifier_str:
-                    sh._emit(f'{qualifier_str} ')
+    def _emit_qualifier(cls, sh, qualifier):
+        """Emit a single parameter direction qualifier"""
+        if qualifier is not None and qualifier.value:
+            sh._emit(f'{qualifier.value} ')
 
     @classmethod
     def _emit_def(
@@ -52,12 +49,12 @@ class BaseType(base.BaseType):
         semantic = None,
         register : int = None,
         initializer = None,
-        qualifiers = None
+        qualifier = None
     ):
         '''
         https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-variable-syntax
         '''
-        cls._emit_qualifiers(sh, qualifiers)
+        cls._emit_qualifier(sh, qualifier)
         
         sh._emit(
             '{type_name} {identifier}'.format(
@@ -77,7 +74,7 @@ class BaseType(base.BaseType):
         allow_init = True,
         semantic = None,
         register = None,
-        qualifiers = None
+        qualifier = None
     ):
         self._bind(sh, identifier, allow_init)
         self.__class__._emit_def(
@@ -85,7 +82,7 @@ class BaseType(base.BaseType):
             initializer = self._expression,
             semantic = semantic,
             register = register,
-            qualifiers = qualifiers
+            qualifier = qualifier
         )
 
     def _assign(self, value):

--- a/metashade/targets/_clike/generator.py
+++ b/metashade/targets/_clike/generator.py
@@ -16,7 +16,7 @@ import types
 import re
 from typing import Annotated
 import metashade.targets._base.generator as base
-from metashade.targets._rtsl.qualifiers import ParamQualifiers, Direction
+from metashade.targets._rtsl.qualifiers import _Out, _InOut
 from . import arrays, context, struct
 
 class Generator(base.Generator):
@@ -61,13 +61,8 @@ class Generator(base.Generator):
         if match:
             qualifier_str, inner_type_name = match.groups()
             inner_type = getattr(self, inner_type_name)
-
-            if qualifier_str == 'Out':
-                direction = Direction.OUT
-            else:
-                direction = Direction.INOUT
-
-            return Annotated[inner_type, ParamQualifiers(direction=direction)]
+            direction = _Out() if qualifier_str == 'Out' else _InOut()
+            return Annotated[inner_type, direction]
 
         return getattr(self, annotation)
 

--- a/metashade/targets/_rtsl/generator.py
+++ b/metashade/targets/_rtsl/generator.py
@@ -14,7 +14,7 @@
 
 from abc import ABC, abstractmethod
 import metashade.targets._clike.generator as clike
-from .qualifiers import Out, InOut
+from .qualifiers import In, Out, InOut
 
 class UniqueKeyChecker(ABC):
     def __init__(self):
@@ -46,10 +46,14 @@ class Generator(clike.Generator, ABC):
     ):
         pass
 
-    def Out(self, base_type):
+    def In(self, base_type, default=None, **kwargs):
+        """Create an input parameter type for function signatures"""
+        return In(base_type, default=default, **kwargs)
+
+    def Out(self, base_type, default=None, **kwargs):
         """Create an output parameter type for function signatures"""
-        return Out(base_type)
+        return Out(base_type, default=default, **kwargs)
     
-    def InOut(self, base_type):
+    def InOut(self, base_type, default=None, **kwargs):
         """Create an input-output parameter type for function signatures"""
-        return InOut(base_type)
+        return InOut(base_type, default=default, **kwargs)

--- a/metashade/targets/_rtsl/generator.py
+++ b/metashade/targets/_rtsl/generator.py
@@ -46,14 +46,14 @@ class Generator(clike.Generator, ABC):
     ):
         pass
 
-    def In(self, base_type, default=None, **kwargs):
+    def In(self, base_type, default=None):
         """Create an input parameter type for function signatures"""
-        return In(base_type, default=default, **kwargs)
+        return In(base_type, default=default)
 
-    def Out(self, base_type, **kwargs):
+    def Out(self, base_type):
         """Create an output parameter type for function signatures"""
-        return Out(base_type, **kwargs)
+        return Out(base_type)
     
-    def InOut(self, base_type, **kwargs):
+    def InOut(self, base_type):
         """Create an input-output parameter type for function signatures"""
-        return InOut(base_type, **kwargs)
+        return InOut(base_type)

--- a/metashade/targets/_rtsl/generator.py
+++ b/metashade/targets/_rtsl/generator.py
@@ -50,10 +50,10 @@ class Generator(clike.Generator, ABC):
         """Create an input parameter type for function signatures"""
         return In(base_type, default=default, **kwargs)
 
-    def Out(self, base_type, default=None, **kwargs):
+    def Out(self, base_type, **kwargs):
         """Create an output parameter type for function signatures"""
-        return Out(base_type, default=default, **kwargs)
+        return Out(base_type, **kwargs)
     
-    def InOut(self, base_type, default=None, **kwargs):
+    def InOut(self, base_type, **kwargs):
         """Create an input-output parameter type for function signatures"""
-        return InOut(base_type, default=default, **kwargs)
+        return InOut(base_type, **kwargs)

--- a/metashade/targets/_rtsl/qualifiers.py
+++ b/metashade/targets/_rtsl/qualifiers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Annotated
+from typing import Annotated, Any
 from dataclasses import dataclass
 
 class Direction(Enum):
@@ -24,14 +24,26 @@ class Direction(Enum):
 @dataclass
 class ParamQualifiers:
     direction: Direction = Direction.IN
+    default: Any = None
 
 # Convenience functions
-def Out(base_type: str) -> type:
-    """Create an output parameter type"""
-    qualifiers = ParamQualifiers(direction=Direction.OUT)
+def In(base_type: str, default: Any = None, **kwargs) -> type:
+    """Create an input parameter type"""
+    qualifiers = ParamQualifiers(
+        direction=Direction.IN, default=default, **kwargs
+    )
     return Annotated[base_type, qualifiers]
 
-def InOut(base_type: str) -> type:
+def Out(base_type: str, default: Any = None, **kwargs) -> type:
+    """Create an output parameter type"""
+    qualifiers = ParamQualifiers(
+        direction=Direction.OUT, default=default, **kwargs
+    )
+    return Annotated[base_type, qualifiers]
+
+def InOut(base_type: str, default: Any = None, **kwargs) -> type:
     """Create an input-output parameter type"""
-    qualifiers = ParamQualifiers(direction=Direction.INOUT)
+    qualifiers = ParamQualifiers(
+        direction=Direction.INOUT, default=default, **kwargs
+    )
     return Annotated[base_type, qualifiers]

--- a/metashade/targets/_rtsl/qualifiers.py
+++ b/metashade/targets/_rtsl/qualifiers.py
@@ -27,23 +27,23 @@ class ParamQualifiers:
     default: Any = None
 
 # Convenience functions
-def In(base_type: str, default: Any = None, **kwargs) -> type:
+def In(base_type: Any, default: Any = None, **kwargs) -> type:
     """Create an input parameter type"""
     qualifiers = ParamQualifiers(
         direction=Direction.IN, default=default, **kwargs
     )
     return Annotated[base_type, qualifiers]
 
-def Out(base_type: str, default: Any = None, **kwargs) -> type:
+def Out(base_type: Any, **kwargs) -> type:
     """Create an output parameter type"""
     qualifiers = ParamQualifiers(
-        direction=Direction.OUT, default=default, **kwargs
+        direction=Direction.OUT, default=None, **kwargs
     )
     return Annotated[base_type, qualifiers]
 
-def InOut(base_type: str, default: Any = None, **kwargs) -> type:
+def InOut(base_type: Any, **kwargs) -> type:
     """Create an input-output parameter type"""
     qualifiers = ParamQualifiers(
-        direction=Direction.INOUT, default=default, **kwargs
+        direction=Direction.INOUT, default=None, **kwargs
     )
     return Annotated[base_type, qualifiers]

--- a/metashade/targets/_rtsl/qualifiers.py
+++ b/metashade/targets/_rtsl/qualifiers.py
@@ -27,23 +27,23 @@ class ParamQualifiers:
     default: Any = None
 
 # Convenience functions
-def In(base_type: Any, default: Any = None, **kwargs) -> type:
+def In(base_type: Any, default: Any = None) -> type:
     """Create an input parameter type"""
     qualifiers = ParamQualifiers(
-        direction=Direction.IN, default=default, **kwargs
+        direction=Direction.IN, default=default
     )
     return Annotated[base_type, qualifiers]
 
-def Out(base_type: Any, **kwargs) -> type:
+def Out(base_type: Any) -> type:
     """Create an output parameter type"""
     qualifiers = ParamQualifiers(
-        direction=Direction.OUT, default=None, **kwargs
+        direction=Direction.OUT, default=None
     )
     return Annotated[base_type, qualifiers]
 
-def InOut(base_type: Any, **kwargs) -> type:
+def InOut(base_type: Any) -> type:
     """Create an input-output parameter type"""
     qualifiers = ParamQualifiers(
-        direction=Direction.INOUT, default=None, **kwargs
+        direction=Direction.INOUT, default=None
     )
     return Annotated[base_type, qualifiers]

--- a/metashade/targets/_rtsl/qualifiers.py
+++ b/metashade/targets/_rtsl/qualifiers.py
@@ -12,38 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
 from typing import Annotated, Any
-from dataclasses import dataclass
 
-class Direction(Enum):
-    IN = ""
-    OUT = "out" 
-    INOUT = "inout"
+class _ParamDirection:
+    """Base class for parameter direction markers in Annotated metadata."""
+    value: str
 
-@dataclass
-class ParamQualifiers:
-    direction: Direction = Direction.IN
-    default: Any = None
+class _In(_ParamDirection):
+    """Input parameter direction. Only inputs can have defaults."""
+    value = ""
+    def __init__(self, default=None):
+        self.default = default
+
+class _Out(_ParamDirection):
+    """Output parameter direction."""
+    value = "out"
+
+class _InOut(_ParamDirection):
+    """Input-output parameter direction."""
+    value = "inout"
 
 # Convenience functions
 def In(base_type: Any, default: Any = None) -> type:
     """Create an input parameter type"""
-    qualifiers = ParamQualifiers(
-        direction=Direction.IN, default=default
-    )
-    return Annotated[base_type, qualifiers]
+    return Annotated[base_type, _In(default=default)]
 
 def Out(base_type: Any) -> type:
     """Create an output parameter type"""
-    qualifiers = ParamQualifiers(
-        direction=Direction.OUT, default=None
-    )
-    return Annotated[base_type, qualifiers]
+    return Annotated[base_type, _Out()]
 
 def InOut(base_type: Any) -> type:
     """Create an input-output parameter type"""
-    qualifiers = ParamQualifiers(
-        direction=Direction.INOUT, default=None
-    )
-    return Annotated[base_type, qualifiers]
+    return Annotated[base_type, _InOut()]

--- a/tests/ref/test_default_args.glsl
+++ b/tests/ref/test_default_args.glsl
@@ -1,0 +1,21 @@
+#version 450
+layout (set = 0, binding = 0) uniform cb
+{
+	vec4 g_f4A;
+	vec4 g_f4B;
+	vec3 g_f3C;
+};
+
+vec4 add_with_default(vec4 a, vec4 b)
+{
+	return a + b;
+}
+
+layout(location = 0) out vec4 out_f4Color;
+void main()
+{
+	vec4 c = add_with_default(g_f4A, vec4(1.0, 1.0, 1.0, 1.0));
+	vec4 c2 = add_with_default(g_f4A, g_f4B);
+	out_f4Color = c + c2;
+}
+

--- a/tests/ref/test_default_args.hlsl
+++ b/tests/ref/test_default_args.hlsl
@@ -1,0 +1,27 @@
+[[vk::binding(0, 0)]]
+cbuffer cb : register(b0)
+{
+	float4 g_f4A;
+	float4 g_f4B;
+	float3 g_f3C;
+};
+
+float4 add_with_default(float4 a, float4 b)
+{
+	return a + b;
+}
+
+struct PsOut
+{
+	float4 color : SV_TARGET;
+};
+
+PsOut main()
+{
+	float4 c = add_with_default(g_f4A, float4(1.0, 1.0, 1.0, 1.0));
+	float4 c2 = add_with_default(g_f4A, g_f4B);
+	PsOut result;
+	result.color = c + c2;
+	return result;
+}
+

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -14,7 +14,7 @@
 
 import pytest
 from metashade.util.testing import ctx_cls_hg, HlslTestContext
-from metashade.targets._rtsl.qualifiers import Direction
+from metashade.targets._rtsl.qualifiers import _Out, _InOut
 
 class TestFunctions:
     def _generate_add_func(self, sh, decl_only = False):
@@ -303,21 +303,19 @@ class TestFunctions:
             assert 'in_param' in func._param_defs
             param_def = func._param_defs['in_param']
             assert param_def.dtype_factory == sh.Float4
-            assert len(param_def.qualifiers) == 0
+            assert param_def.direction is None
             
             # Check 'out_param' parameter
             assert 'out_param' in func._param_defs
             param_def = func._param_defs['out_param']
             assert param_def.dtype_factory == sh.Float3
-            assert len(param_def.qualifiers) == 1
-            assert param_def.qualifiers[0].direction == Direction.OUT
+            assert isinstance(param_def.direction, _Out)
             
             # Check 'inout_param' parameter
             assert 'inout_param' in func._param_defs
             param_def = func._param_defs['inout_param']
             assert param_def.dtype_factory == sh.Float2
-            assert len(param_def.qualifiers) == 1
-            assert param_def.qualifiers[0].direction == Direction.INOUT
+            assert isinstance(param_def.direction, _InOut)
 
     @ctx_cls_hg
     def test_void_function_reflection(self, ctx_cls):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -109,6 +109,31 @@ class TestFunctions:
                 sh.result.color = sh.add(a = sh.g_f4A)
 
     @ctx_cls_hg
+    def test_default_args(self, ctx_cls):
+        ctx = ctx_cls()
+        with ctx as sh:
+            self._generate_test_uniforms(sh)
+            
+            with sh.function('add_with_default', sh.Float4)(
+                a = sh.Float4, 
+                b = sh.In(sh.Float4, default=(1.0, 1.0, 1.0, 1.0))
+            ):
+                sh.return_(sh.a + sh.b)
+
+            with self._generate_ps_main_decl(sh, ctx):
+                # Call without second arg
+                sh.c = sh.add_with_default(a = sh.g_f4A)
+                # Call overriding second arg
+                sh.c2 = sh.add_with_default(a = sh.g_f4A, b = sh.g_f4B)
+
+                if isinstance(ctx, HlslTestContext):
+                    sh.result = sh.PsOut()
+                    sh.result.color = sh.c + sh.c2
+                    sh.return_(sh.result)
+                else:
+                    sh.out_f4Color = sh.c + sh.c2
+
+    @ctx_cls_hg
     def test_extra_arg(self, ctx_cls):
         with ctx_cls(no_file = True) as sh:
             self._generate_test_uniforms(sh)


### PR DESCRIPTION
Introduces isolated support for the \sh.In\/default metadata syntax natively into Metashade's \sh.function\ Context Manager pattern.