### PR TITLE
Pin MaterialX version and scope mtlx ref dir env var

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest MaterialX
+        python -m pip install flake8 pytest MaterialX==1.39.5
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/metashade/mtlx/util/testing.py
+++ b/metashade/mtlx/util/testing.py
@@ -27,7 +27,7 @@ class GlslTestContext(GlslGeneratorContext):
         out_dir = os.getenv('METASHADE_PYTEST_OUT_DIR', None)
         
         ref_dir_env = os.getenv('METASHADE_MTLX_PYTEST_REF_DIR', None)
-        if ref_dir_env is not None:
+        if ref_dir_env:
             ref_dir = Path(ref_dir_env).resolve()
         else:
             # Assuming tests are in tests/mtlx, refs are in tests/ref/mtlx

--- a/metashade/mtlx/util/testing.py
+++ b/metashade/mtlx/util/testing.py
@@ -25,8 +25,13 @@ class GlslTestContext(GlslGeneratorContext):
         
         # Consistent with metashade.util.testing
         out_dir = os.getenv('METASHADE_PYTEST_OUT_DIR', None)
-        # Assuming tests are in tests/mtlx, refs are in tests/ref/mtlx
-        ref_dir = test_dir.parent / 'ref' / 'mtlx'
+        
+        ref_dir_env = os.getenv('METASHADE_MTLX_PYTEST_REF_DIR', None)
+        if ref_dir_env is not None:
+            ref_dir = Path(ref_dir_env).resolve()
+        else:
+            # Assuming tests are in tests/mtlx, refs are in tests/ref/mtlx
+            ref_dir = test_dir.parent / 'ref' / 'mtlx'
 
         if out_dir is None:
             # Update mode: write directly to reference directory


### PR DESCRIPTION
## Summary

- **Pin MaterialX==1.39.5** in CI to ensure test baselines always match the installed version
- **Add METASHADE_MTLX_PYTEST_REF_DIR** env var to allow the MaterialX fork to redirect ref comparisons to its own baselines

## Rationale

MaterialX reference outputs (discovered node lists, generated GLSL/MTLX) differ between releases. When CI installs a newer version than the baselines were generated against, verbatim `RefDiffer` comparisons fail.

Rather than building multi-version test infrastructure (which requires separate virtualenvs, CI matrix entries, and can't work in a single Test Explorer session), we pin one explicit version for Metashade's standalone tests. The MaterialX fork handles cross-version testing separately.

The `METASHADE_MTLX_PYTEST_REF_DIR` env var is introduced so the MaterialX fork can point mtlx tests at its own ref directory, preventing accidental overwrites of Metashade's refs.

## Changes

| File | Change |
|---|---|
| `.github/workflows/python-package.yml` | Pin `MaterialX==1.39.5` |
| `metashade/mtlx/util/testing.py` | Add `METASHADE_MTLX_PYTEST_REF_DIR` env var support |