### PR TITLE
Add subdir scoping to GlslTestContext for multi-environment support

### DIFF
--- a/metashade/mtlx/mtlx_reflection.py
+++ b/metashade/mtlx/mtlx_reflection.py
@@ -153,17 +153,20 @@ def acquire_stdlib(sh, doc, target: str) -> dict[str, 'Function']:
     return functions
 
 
-def generate_wrapper_func(sh, impl, suffix: str = "_metashade"):
+def generate_wrapper_func(sh, impl, suffix: str = "_metashade", body=None):
     """
     Generate a wrapper function for a MaterialX implementation.
     
     Includes the source file and generates a wrapper that calls
-    the original function.
+    the original function — unless ``body`` is provided.
     
     Args:
         sh: The Metashade generator instance
         impl: A PyMaterialX nodeimpl object
         suffix: Suffix for the wrapper function name
+        body: Optional callback ``(sh, orig_func) -> None`` that emits the
+              function body using the EDSL.  When *None* the wrapper
+              performs a pass-through call to the original function.
         
     Returns:
         The wrapper Function object, or None if not wrappable
@@ -217,7 +220,10 @@ def generate_wrapper_func(sh, impl, suffix: str = "_metashade"):
     
     # Define the wrapper function
     with sh.function(wrapper_name)(**params):
-        call_args = {name: getattr(sh, name) for name in params}
-        orig_func(**call_args)
+        if body is not None:
+            body(sh, orig_func)
+        else:
+            call_args = {name: getattr(sh, name) for name in params}
+            orig_func(**call_args)
     
     return getattr(sh, wrapper_name)

--- a/metashade/mtlx/util/testing.py
+++ b/metashade/mtlx/util/testing.py
@@ -34,17 +34,19 @@ class GlslTestContext(GlslGeneratorContext):
             ref_dir = test_dir.parent / 'ref' / 'mtlx'
 
         if out_dir is None:
-            # Update mode: write directly to reference directory
-            cls._out_dir = ref_dir
-            cls._ref_differ = None
+            # Update mode: write directly to reference directory.
+            # No comparison — the developer examines diffs in git.
+            cls._out_dir_root = ref_dir
+            cls._ref_dir_root = None
         else:
             # Compare mode: write to temp dir and compare
-            cls._out_dir = Path(out_dir).resolve() / 'mtlx'
-            cls._ref_differ = RefDiffer(ref_dir)
+            cls._out_dir_root = Path(out_dir).resolve() / 'mtlx'
+            cls._ref_dir_root = ref_dir
         
-        os.makedirs(cls._out_dir, exist_ok=True)
+        os.makedirs(cls._out_dir_root, exist_ok=True)
 
-    def __init__(self, base_name: str = None, impl_only: bool = False):
+    def __init__(self, base_name: str = None, impl_only: bool = False,
+                 subdir: str = None):
         """
         Initialize a GLSL test context.
         
@@ -53,20 +55,33 @@ class GlslTestContext(GlslGeneratorContext):
                        If not provided, uses the test function name.
                        For library-level overrides, use e.g., 'metashade_pbrlib'
             impl_only: If True, skip nodedef generation (for overrides)
+            subdir: Optional subdirectory within the output/ref dirs.
+                    Used to scope generated files per experiment/environment.
         """
         if base_name is None:
             base_name = get_test_func_name()
-        super().__init__(base_name, self._out_dir, impl_only=impl_only)
+
+        out_dir = self._out_dir_root
+        if subdir is not None:
+            out_dir = out_dir / subdir
+        os.makedirs(out_dir, exist_ok=True)
+
+        self._subdir = subdir
+        super().__init__(base_name, out_dir, impl_only=impl_only)
 
     def __exit__(self, exc_type, exc_value, traceback):
         # Allow parent to generate files first
         success = super().__exit__(exc_type, exc_value, traceback)
         
-        if success and self._ref_differ is not None:
-            # Verify generated files against references
+        if success and self._ref_dir_root is not None:
+            ref_dir = self._ref_dir_root
+            if self._subdir is not None:
+                ref_dir = ref_dir / self._subdir
+            ref_differ = RefDiffer(ref_dir)
+
             if self._nodedef_doc_path is not None:
-                self._ref_differ(self._nodedef_doc_path)
-            self._ref_differ(self._impl_doc_path)
-            self._ref_differ(self._src_path)
+                ref_differ(self._nodedef_doc_path)
+            ref_differ(self._impl_doc_path)
+            ref_differ(self._src_path)
             
         return success

--- a/tests/mtlx/test_mtlx_schlick_bsdf.py
+++ b/tests/mtlx/test_mtlx_schlick_bsdf.py
@@ -26,27 +26,24 @@ from metashade.mtlx.dtypes import register_mtlx_closure_structs
 from metashade.mtlx.util.testing import GlslTestContext
 
 
-class TestSchlickBsdfWrapper:
-    """Tests for generating wrapper for generalized_schlick_bsdf."""
-    
-    @pytest.fixture
-    def schlick_impl(self, stdlib_doc: mx.Document):
-        """Get the localized implementation for generalized_schlick_bsdf."""
-        # Find implementation for "genglsl" target
-        for impl in stdlib_doc.getImplementations():
-            if (
-                impl.getNodeDefString().endswith("generalized_schlick_bsdf") and
-                impl.getTarget() == "genglsl"
-            ):
-                return impl
-        
-        # Fallback: try searching by nodedef name directly if possible, or just print what we have
-        # But 'ending with' is safer because names can have prefixes
-        pytest.fail("Could not find genglsl implementation for generalized_schlick_bsdf")
+@pytest.fixture
+def schlick_impl(stdlib_doc: mx.Document):
+    """Get the genglsl implementation for generalized_schlick_bsdf."""
+    for impl in stdlib_doc.getImplementations():
+        if (
+            impl.getNodeDefString().endswith("generalized_schlick_bsdf") and
+            impl.getTarget() == "genglsl"
+        ):
+            return impl
+    pytest.fail("Could not find genglsl implementation for generalized_schlick_bsdf")
 
-    def test_generate_schlick_wrapper(self, schlick_impl):
+
+class TestSchlickBsdfPassthru:
+    """Passthru wrapper: calls the original Schlick unchanged."""
+
+    def test_generate_schlick_passthru(self, schlick_impl):
         """
-        Generate a wrapper implementation for generalized_schlick_bsdf.
+        Generate a passthru wrapper implementation for generalized_schlick_bsdf.
         
         This verifies we can acquire the standard node and re-emit it 
         as a Metashade-managed implementation (Phase 2 acquisition).
@@ -63,16 +60,55 @@ class TestSchlickBsdfWrapper:
             # Declare standard MaterialX closure structs
             register_mtlx_closure_structs(sh)
             
-            # 1. Generate the wrapper function in Metashade
+            # Generate the wrapper function in Metashade
             wrapper = generate_wrapper_func(sh, schlick_impl)
             
             assert wrapper is not None
             assert hasattr(sh, wrapper._name)
             
-            # 2. Register this wrapper as an implementation for the ORIGINAL nodedef
-            # This is the "overload" part - providing a new implementation for ND_generalized_schlick_bsdf
+            # Register this wrapper as an implementation for the ORIGINAL nodedef
             test_ctx.add_node_impl(
                 func_name=wrapper._name,
-                mx_doc_string="Metashade wrapper for generalized_schlick_bsdf",
+                mx_doc_string="Metashade passthru wrapper for generalized_schlick_bsdf",
+                nodedef_name="ND_generalized_schlick_bsdf"
+            )
+
+
+class TestSchlickBsdfBroken:
+    """Broken Schlick: returns hot pink, proving the override pipeline works."""
+
+    def test_generate_broken_schlick(self, schlick_impl):
+        """
+        Generate a deliberately broken Schlick that returns hot pink.
+        
+        Uses the body callback to override the default passthru behavior,
+        validating both the callback mechanism and the subdir scoping.
+        """
+        def broken_body(sh, orig_func):
+            sh.out_.response = [1.0, 0.0, 0.5]
+            sh.out_.throughput = [0.0, 0.0, 0.0]
+
+        ctx = GlslTestContext(
+            base_name="mx_generalized_schlick_bsdf_broken",
+            impl_only=True,
+            subdir="broken_schlick"
+        )
+        
+        with ctx as test_ctx:
+            sh = test_ctx._sh
+            
+            register_mtlx_closure_structs(sh)
+            
+            wrapper = generate_wrapper_func(
+                sh, schlick_impl,
+                suffix="_broken",
+                body=broken_body
+            )
+            
+            assert wrapper is not None
+            
+            test_ctx.add_node_impl(
+                func_name=wrapper._name,
+                mx_doc_string="Broken Schlick: returns hot pink to validate override pipeline",
                 nodedef_name="ND_generalized_schlick_bsdf"
             )

--- a/tests/mtlx/test_mtlx_src_node_discovery.py
+++ b/tests/mtlx/test_mtlx_src_node_discovery.py
@@ -29,6 +29,7 @@ import pytest
 # Skip if MaterialX is not installed
 mx = pytest.importorskip("MaterialX")
 
+from metashade.util.testing import RefDiffer
 from metashade.mtlx.util.testing import GlslTestContext
 
 
@@ -132,9 +133,9 @@ class TestNodeDiscovery:
         content = "\n".join(lines) + "\n"
         
         # Write to output file
-        out_path = GlslTestContext._out_dir / "source_code_nodes.txt"
+        out_path = GlslTestContext._out_dir_root / "source_code_nodes.txt"
         out_path.write_text(content)
         
         # Compare against reference if in compare mode
-        if GlslTestContext._ref_differ is not None:
-            GlslTestContext._ref_differ(out_path)
+        if GlslTestContext._ref_dir_root is not None:
+            RefDiffer(GlslTestContext._ref_dir_root)(out_path)

--- a/tests/ref/mtlx/broken_schlick/mx_generalized_schlick_bsdf_broken_genglsl_impl.glsl
+++ b/tests/ref/mtlx/broken_schlick/mx_generalized_schlick_bsdf_broken_genglsl_impl.glsl
@@ -1,0 +1,7 @@
+#include "mx_generalized_schlick_bsdf.glsl"
+void mx_generalized_schlick_bsdf_broken(ClosureData closureData, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, bool retroreflective, float thinfilm_thickness, float thinfilm_ior, vec3 normal, vec3 tangent, int distribution, int scatter_mode, out BSDF out_)
+{
+	out_.response = vec3(1.0, 0.0, 0.5);
+	out_.throughput = vec3(0.0, 0.0, 0.0);
+}
+

--- a/tests/ref/mtlx/broken_schlick/mx_generalized_schlick_bsdf_broken_genglsl_impl.mtlx
+++ b/tests/ref/mtlx/broken_schlick/mx_generalized_schlick_bsdf_broken_genglsl_impl.mtlx
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <implementation name="IM_generalized_schlick_bsdf_broken_genglsl" nodedef="ND_generalized_schlick_bsdf" target="genglsl" file="mx_generalized_schlick_bsdf_broken_genglsl_impl.glsl" function="mx_generalized_schlick_bsdf_broken" doc="Broken Schlick: returns hot pink to validate override pipeline" />
+</materialx>

--- a/tests/ref/mtlx/mx_generalized_schlick_bsdf_metashade_genglsl_impl.mtlx
+++ b/tests/ref/mtlx/mx_generalized_schlick_bsdf_metashade_genglsl_impl.mtlx
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <implementation name="IM_generalized_schlick_bsdf_metashade_genglsl" nodedef="ND_generalized_schlick_bsdf" target="genglsl" file="mx_generalized_schlick_bsdf_metashade_genglsl_impl.glsl" function="mx_generalized_schlick_bsdf_metashade" doc="Metashade wrapper for generalized_schlick_bsdf" />
+  <implementation name="IM_generalized_schlick_bsdf_metashade_genglsl" nodedef="ND_generalized_schlick_bsdf" target="genglsl" file="mx_generalized_schlick_bsdf_metashade_genglsl_impl.glsl" function="mx_generalized_schlick_bsdf_metashade" doc="Metashade passthru wrapper for generalized_schlick_bsdf" />
 </materialx>


### PR DESCRIPTION
## Summary

- Adds a `subdir` parameter to `GlslTestContext` so generated files can be organized into subdirectories per experiment/environment (e.g., `broken_schlick/`)
- `RefDiffer` comparison is scoped to the matching subdirectory in compare mode
- Renames `_out_dir` -> `_out_dir_root` and `_ref_differ` -> `_ref_dir_root` for clarity
- Adds an optional `body` callback to `generate_wrapper_func` so callers can customise the emitted function body via the EDSL instead of always performing a pass-through call
- Adds `TestSchlickBsdfBroken` which uses the callback to emit a hot-pink BSDF override, exercising both the callback mechanism and the subdir scoping

## Motivation

Multi-environment Metashade overrides (metashade/MaterialX#13) need each environment's generated files in separate subdirectories. This change is the infrastructure prerequisite, validated end-to-end with a deliberately broken Schlick that returns hot pink.

## Test plan

- [x] Existing tests pass without `subdir` (backward compatible)
- [x] Broken Schlick environment generates into `broken_schlick/` subdir
- [x] Reference files generated against pinned `MaterialX==1.39.5` in an isolated venv
- [x] CI green on Python 3.9, 3.10, 3.11