### PR TITLE
mtlx: Use `inout` qualifier and type-based names for closure outputs

### DIFF
--- a/metashade/mtlx/generate.py
+++ b/metashade/mtlx/generate.py
@@ -17,7 +17,7 @@ import abc
 
 import MaterialX as mx
 from metashade.targets.glsl import frag
-from metashade.targets._clike.context import Out
+from metashade.targets._clike.context import Out, InOut
 
 from metashade.mtlx import dtypes
 
@@ -114,7 +114,7 @@ class GeneratorContext:
 
             # Add parameters in their original order
             for param_name, param in func._param_defs.items():
-                is_output = isinstance(param, Out)
+                is_output = isinstance(param, (Out, InOut))
                 param_type = dtypes.metashade_to_mtlx(param.dtype_factory)
                 
                 if is_output:

--- a/metashade/mtlx/mtlx_reflection.py
+++ b/metashade/mtlx/mtlx_reflection.py
@@ -53,6 +53,42 @@ def _sanitize_identifier(name: str) -> str:
     return name
 
 
+def _build_params(sh, nodedef, context: str) -> dict:
+    """Build parameter annotations from a MaterialX nodedef.
+
+    Closure output types (BSDF, EDF, VDF) are emitted as ``inout`` and
+    named after their type (e.g. ``bsdf``) to match the standard library
+    convention.  Non-closure outputs use ``out`` with a sanitized name.
+    """
+    params = {}
+
+    if _node_needs_closure_data(nodedef):
+        params['closureData'] = sh.ClosureData
+
+    for input in nodedef.getInputs():
+        dtype = mtlx_to_metashade_dtype(input.getType(), sh)
+        if dtype is None:
+            raise TypeError(
+                f"Cannot map MaterialX type '{input.getType()}' for input "
+                f"'{input.getName()}' in {context}"
+            )
+        params[_sanitize_identifier(input.getName())] = dtype
+
+    for output in nodedef.getOutputs():
+        dtype = mtlx_to_metashade_dtype(output.getType(), sh)
+        if dtype is None:
+            raise TypeError(
+                f"Cannot map MaterialX type '{output.getType()}' for output "
+                f"'{output.getName()}' in {context}"
+            )
+        is_closure = output.getType() in _CLOSURE_OUTPUT_TYPES
+        name = output.getType().lower() if is_closure else _sanitize_identifier(output.getName())
+        wrapper = sh.InOut if is_closure else sh.Out
+        params[name] = wrapper(dtype)
+
+    return params
+
+
 def acquire_function(sh, impl):
     """
     Acquire a MaterialX function into the generator.
@@ -83,32 +119,7 @@ def acquire_function(sh, impl):
     if hasattr(sh, func_attr):
         return getattr(sh, func_attr)
     
-    # Build param annotations (inputs then outputs)
-    param_annotations = {}
-    
-    # Closure-type nodes get ClosureData as first parameter
-    if _node_needs_closure_data(nodedef):
-        param_annotations['closureData'] = sh.ClosureData
-    
-    for input in nodedef.getInputs():
-        dtype = mtlx_to_metashade_dtype(input.getType(), sh)
-        if dtype is None:
-            raise TypeError(
-                f"Cannot map MaterialX type '{input.getType()}' for input "
-                f"'{input.getName()}' in {func_attr}"
-            )
-        param_name = _sanitize_identifier(input.getName())
-        param_annotations[param_name] = dtype
-    
-    for output in nodedef.getOutputs():
-        dtype = mtlx_to_metashade_dtype(output.getType(), sh)
-        if dtype is None:
-            raise TypeError(
-                f"Cannot map MaterialX type '{output.getType()}' for output "
-                f"'{output.getName()}' in {func_attr}"
-            )
-        param_name = _sanitize_identifier(output.getName())
-        param_annotations[param_name] = sh.Out(dtype)
+    param_annotations = _build_params(sh, nodedef, func_attr)
     
     # Declare the function without emitting code
     FunctionDecl(sh, func_attr, return_type=None)(
@@ -190,34 +201,8 @@ def generate_wrapper_func(sh, impl, suffix: str = "_metashade", body=None):
         return None
     
     wrapper_name = f"{func_attr}{suffix}"
-    
-    # Build parameter dict for wrapper
-    params = {}
-    
-    # Closure-type nodes get ClosureData as first parameter
-    if _node_needs_closure_data(nodedef):
-        params['closureData'] = sh.ClosureData
-    
-    for input in nodedef.getInputs():
-        dtype = mtlx_to_metashade_dtype(input.getType(), sh)
-        if dtype is None:
-            raise TypeError(
-                f"Cannot map MaterialX type '{input.getType()}' for input "
-                f"'{input.getName()}' in {wrapper_name}"
-            )
-        param_name = _sanitize_identifier(input.getName())
-        params[param_name] = dtype
-    
-    for output in nodedef.getOutputs():
-        dtype = mtlx_to_metashade_dtype(output.getType(), sh)
-        if dtype is None:
-            raise TypeError(
-                f"Cannot map MaterialX type '{output.getType()}' for output "
-                f"'{output.getName()}' in {wrapper_name}"
-            )
-        param_name = _sanitize_identifier(output.getName())
-        params[param_name] = sh.Out(dtype)
-    
+    params = _build_params(sh, nodedef, wrapper_name)
+
     # Define the wrapper function
     with sh.function(wrapper_name)(**params):
         if body is not None:

--- a/tests/mtlx/test_mtlx_schlick_bsdf.py
+++ b/tests/mtlx/test_mtlx_schlick_bsdf.py
@@ -86,8 +86,8 @@ class TestSchlickBsdfBroken:
         validating both the callback mechanism and the subdir scoping.
         """
         def broken_body(sh, orig_func):
-            sh.out_.response = [1.0, 0.0, 0.5]
-            sh.out_.throughput = [0.0, 0.0, 0.0]
+            sh.bsdf.response = [1.0, 0.0, 0.5]
+            sh.bsdf.throughput = [0.0, 0.0, 0.0]
 
         ctx = GlslTestContext(
             base_name="mx_generalized_schlick_bsdf_broken",

--- a/tests/ref/mtlx/broken_schlick/mx_generalized_schlick_bsdf_broken_genglsl_impl.glsl
+++ b/tests/ref/mtlx/broken_schlick/mx_generalized_schlick_bsdf_broken_genglsl_impl.glsl
@@ -1,7 +1,7 @@
 #include "mx_generalized_schlick_bsdf.glsl"
-void mx_generalized_schlick_bsdf_broken(ClosureData closureData, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, bool retroreflective, float thinfilm_thickness, float thinfilm_ior, vec3 normal, vec3 tangent, int distribution, int scatter_mode, out BSDF out_)
+void mx_generalized_schlick_bsdf_broken(ClosureData closureData, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, bool retroreflective, float thinfilm_thickness, float thinfilm_ior, vec3 normal, vec3 tangent, int distribution, int scatter_mode, inout BSDF bsdf)
 {
-	out_.response = vec3(1.0, 0.0, 0.5);
-	out_.throughput = vec3(0.0, 0.0, 0.0);
+	bsdf.response = vec3(1.0, 0.0, 0.5);
+	bsdf.throughput = vec3(0.0, 0.0, 0.0);
 }
 

--- a/tests/ref/mtlx/source_code_node_passthrus/mx_generalized_schlick_bsdf_metashade_genglsl_impl.glsl
+++ b/tests/ref/mtlx/source_code_node_passthrus/mx_generalized_schlick_bsdf_metashade_genglsl_impl.glsl
@@ -1,6 +1,6 @@
 #include "mx_generalized_schlick_bsdf.glsl"
-void mx_generalized_schlick_bsdf_metashade(ClosureData closureData, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, bool retroreflective, float thinfilm_thickness, float thinfilm_ior, vec3 normal, vec3 tangent, int distribution, int scatter_mode, out BSDF out_)
+void mx_generalized_schlick_bsdf_metashade(ClosureData closureData, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, bool retroreflective, float thinfilm_thickness, float thinfilm_ior, vec3 normal, vec3 tangent, int distribution, int scatter_mode, inout BSDF bsdf)
 {
-	mx_generalized_schlick_bsdf(closureData, weight, color0, color82, color90, exponent, roughness, retroreflective, thinfilm_thickness, thinfilm_ior, normal, tangent, distribution, scatter_mode, out_);
+	mx_generalized_schlick_bsdf(closureData, weight, color0, color82, color90, exponent, roughness, retroreflective, thinfilm_thickness, thinfilm_ior, normal, tangent, distribution, scatter_mode, bsdf);
 }
 


### PR DESCRIPTION
## Summary

- Extract `_build_params()` helper in `mtlx_reflection.py` to eliminate duplicated parameter-building logic between `acquire_function()` and `generate_wrapper_func()`.
- Closure output types (`BSDF`, `EDF`, `VDF`) are now emitted with the `inout` qualifier and named after their type (e.g. `bsdf`) instead of `out out_`, matching the MaterialX standard library convention.
- Update the broken Schlick test body callback to use `sh.bsdf` instead of `sh.out_`.

Required for metashade/MaterialX#26

## Test plan

- [ ] Run Metashade unit tests (`pytest tests/`)
- [ ] Regenerate passthru GLSL and verify `inout bsdf` in output
- [ ] Run MaterialX render tests to confirm no regressions