### PR TITLE
chore: Update PyPI project urls in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Homepage = "https://metashade.dev"
 Documentation = "https://metashade.dev"
 Repository = "https://github.com/metashade/metashade"
 Issues = "https://github.com/metashade/metashade/issues"
-"Releases" = "https://github.com/metashade/metashade/releases"
+Releases = "https://github.com/metashade/metashade/releases"
 "PyCon DE 2026 Presentation" = "https://metashade.dev/metashade-pyconde-pydata-2026/"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,12 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/metashade/metashade"
+Homepage = "https://metashade.dev"
+Documentation = "https://metashade.dev"
 Repository = "https://github.com/metashade/metashade"
 Issues = "https://github.com/metashade/metashade/issues"
-Documentation = "https://github.com/metashade/metashade/blob/main/README.md"
+"Releases" = "https://github.com/metashade/metashade/releases"
+"PyCon DE 2026 Presentation" = "https://metashade.dev/metashade-pyconde-pydata-2026/"
 
 [project.optional-dependencies]
 mtlx = [


### PR DESCRIPTION
This PR updates the PyPI project URLs metadata in pyproject.toml to point to the new metashade.dev domain, adds a Releases link pointing to GitHub Releases, and includes the PyCon DE 2026 Presentation link.