### PR TITLE
fix: Use shallow=False in RefDiffer filecmp.cmp

### DIFF
--- a/metashade/util/testing.py
+++ b/metashade/util/testing.py
@@ -27,7 +27,7 @@ class RefDiffer:
         self._ref_dir = ref_dir
 
     def __call__(self, path : Path):
-        assert filecmp.cmp(path, self._ref_dir / path.name)
+        assert filecmp.cmp(path, self._ref_dir / path.name, shallow=False)
 
 def get_test_func_name():
     for frame in inspect.stack():


### PR DESCRIPTION
## Summary

- `filecmp.cmp` defaults to `shallow=True`, comparing `os.stat` metadata
  (size + mtime) rather than file contents. For a CI baseline gate this
  risks false passes when stat signatures happen to match.
- Pass `shallow=False` for byte-for-byte comparison.

Spotted by Copilot review on [metashade/MaterialX#33](https://github.com/metashade/MaterialX/pull/33).

## Test plan

- Existing tests pass (no behavior change when files actually differ)