### PR TITLE
ci: Add weekly Friday scheduled build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,6 +8,10 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    # Every Friday at 8:00 AM EDT (12:00 UTC)
+    - cron: '0 12 * * 5'
+
 
 jobs:
   build:


### PR DESCRIPTION
Adds a scheduled GitHub Actions cron trigger to run the Python package workflow every Friday at 8:00 AM EDT (12:00 UTC) to catch external dependency shifts early.