### PR TITLE
Pass metalness as conductor_bsdf weight for early-exit optimization

### DIFF
--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -295,7 +295,7 @@ class TestStandardSurfaceDefault:
                 sh.metal_bsdf.throughput = [1.0, 1.0, 1.0]
                 sh.mx_conductor_bsdf(
                     closureData=sh.closureData,
-                    weight=1.0,
+                    weight=sh.metalness,
                     ior=sh.ior_n,
                     extinction=sh.ior_k,
                     roughness=sh.main_roughness,
@@ -309,13 +309,15 @@ class TestStandardSurfaceDefault:
                 )
 
                 # --- Metalness mix: conductor (fg) vs specular+diffuse (bg) ---
+                # Conductor response is already scaled by metalness (the weight),
+                # so we just add it to the attenuated dielectric+diffuse stack.
                 sh.one_minus_metalness = sh.Float(1) - sh.metalness
                 sh.bsdf.response = (
-                    sh.metal_bsdf.response * sh.metalness
+                    sh.metal_bsdf.response
                     + sh.bsdf.response * sh.one_minus_metalness
                 )
                 sh.bsdf.throughput = (
-                    sh.metal_bsdf.throughput * sh.metalness
+                    sh.metal_bsdf.throughput
                     + sh.bsdf.throughput * sh.one_minus_metalness
                 )
 

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -25,9 +25,9 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	BSDF metal_bsdf;
 	metal_bsdf.response = vec3(0.0, 0.0, 0.0);
 	metal_bsdf.throughput = vec3(1.0, 1.0, 1.0);
-	mx_conductor_bsdf(closureData, 1.0, ior_n, ior_k, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, tangent, 0, metal_bsdf);
+	mx_conductor_bsdf(closureData, metalness, ior_n, ior_k, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, tangent, 0, metal_bsdf);
 	float one_minus_metalness = 1 - metalness;
-	bsdf.response = (metal_bsdf.response * metalness) + (bsdf.response * one_minus_metalness);
-	bsdf.throughput = (metal_bsdf.throughput * metalness) + (bsdf.throughput * one_minus_metalness);
+	bsdf.response = metal_bsdf.response + (bsdf.response * one_minus_metalness);
+	bsdf.throughput = metal_bsdf.throughput + (bsdf.throughput * one_minus_metalness);
 }
 


### PR DESCRIPTION
## Summary
- Pass `metalness` as the `weight` parameter to `mx_conductor_bsdf` instead of `1.0`
- Adjust the metalness mix to account for the weight already being baked into the conductor response
- When `metalness == 0`, the conductor BSDF early-returns, avoiding a full microfacet evaluation whose result would be discarded

Follow-up to #210.

## Test plan
- [x] All 6 Standard Surface render tests pass (default, plastic, gold, chrome, greysphere, thin_film)
- [x] FLIP comparison against stdlib reference renders passes within threshold