### PR TITLE
Add emission EDF to Standard Surface thin nodegraph

### DIFF
--- a/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
+++ b/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
@@ -3,9 +3,9 @@
   <!--
     Thin nodegraph overriding ND_standard_surface_surfaceshader.
     Wires the Metashade-generated metashade_standard_surface_bsdf node
-    to the stock surface constructor.  Only the inputs used by the BSDF
-    node are forwarded; unused SS inputs (coat, sheen, subsurface, etc.)
-    are left unconnected.
+    and a standard-library emission EDF to the stock surface constructor.
+    Only the inputs consumed by existing nodes are forwarded; unused SS
+    inputs (coat, sheen, subsurface, etc.) are left unconnected.
   -->
   <nodegraph name="NG_metashade_standard_surface" nodedef="ND_standard_surface_surfaceshader">
 
@@ -25,8 +25,18 @@
       <input name="tangent" type="vector3" interfacename="tangent" />
     </metashade_standard_surface_bsdf>
 
+    <multiply name="emission_weight" type="color3">
+      <input name="in1" type="color3" interfacename="emission_color" />
+      <input name="in2" type="float" interfacename="emission" />
+    </multiply>
+
+    <uniform_edf name="emission_edf" type="EDF">
+      <input name="color" type="color3" nodename="emission_weight" />
+    </uniform_edf>
+
     <surface name="surface_ctor" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="ss_bsdf" />
+      <input name="edf" type="EDF" nodename="emission_edf" />
     </surface>
 
     <output name="out" type="surfaceshader" nodename="surface_ctor" />


### PR DESCRIPTION
## Summary
- Wire `emission_color * emission` -> `uniform_edf` -> `surface` constructor's `edf` input in the thin nodegraph overriding `ND_standard_surface_surfaceshader`.
- Matches the reference `NG_standard_surface_surfaceshader_100` emission path (without coat interaction, which will come later).
- No source-code node changes needed — emission uses standard MaterialX `multiply` and `uniform_edf` nodes.

## Test plan
- [x] All existing Standard Surface render tests pass (default, plastic, gold, chrome, greysphere, thin_film)
- [x] Generated shader dumps include `mx_uniform_edf` and emission contribution