### PR TITLE
Add opacity to Standard Surface thin nodegraph

### DIFF
--- a/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
+++ b/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
@@ -3,9 +3,9 @@
   <!--
     Thin nodegraph overriding ND_standard_surface_surfaceshader.
     Wires the Metashade-generated metashade_standard_surface_bsdf node
-    and a standard-library emission EDF to the stock surface constructor.
-    Only the inputs consumed by existing nodes are forwarded; unused SS
-    inputs (coat, sheen, subsurface, etc.) are left unconnected.
+    and standard-library emission and opacity nodes to the stock surface
+    constructor.  Only the inputs consumed by existing nodes are forwarded;
+    unused SS inputs (coat, sheen, subsurface, etc.) are left unconnected.
   -->
   <nodegraph name="NG_metashade_standard_surface" nodedef="ND_standard_surface_surfaceshader">
 
@@ -34,9 +34,19 @@
       <input name="color" type="color3" nodename="emission_weight" />
     </uniform_edf>
 
+    <luminance name="opacity_luminance" type="color3">
+      <input name="in" type="color3" interfacename="opacity" />
+    </luminance>
+
+    <extract name="opacity_luminance_float" type="float">
+      <input name="in" type="color3" nodename="opacity_luminance" />
+      <input name="index" type="integer" value="0" />
+    </extract>
+
     <surface name="surface_ctor" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="ss_bsdf" />
       <input name="edf" type="EDF" nodename="emission_edf" />
+      <input name="opacity" type="float" nodename="opacity_luminance_float" />
     </surface>
 
     <output name="out" type="surfaceshader" nodename="surface_ctor" />


### PR DESCRIPTION
## Summary
- Wire `luminance(opacity)` -> `extract(index=0)` -> `surface` constructor's `opacity` input in the thin nodegraph.
- Matches the reference `NG_standard_surface_surfaceshader_100` opacity path.
- No source-code node changes needed — uses standard MaterialX `luminance` and `extract` nodes.

**Note:** No existing Standard Surface example materials set non-default opacity, so the path is verified structurally via shader dumps only.

## Test plan
- [x] All existing render tests pass (81 passed, 172 subtests)
- [x] Shader dumps include `mx_luminance_color3`, `surfaceOpacity` wiring