### PR TITLE
Add transmission BSDF to Standard Surface

### DIFF
--- a/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
+++ b/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
@@ -19,6 +19,9 @@
       <input name="specular_IOR" type="float" interfacename="specular_IOR" />
       <input name="metalness" type="float" interfacename="metalness" />
       <input name="specular_anisotropy" type="float" interfacename="specular_anisotropy" />
+      <input name="transmission" type="float" interfacename="transmission" />
+      <input name="transmission_color" type="color3" interfacename="transmission_color" />
+      <input name="transmission_extra_roughness" type="float" interfacename="transmission_extra_roughness" />
       <input name="thin_film_thickness" type="float" interfacename="thin_film_thickness" />
       <input name="thin_film_IOR" type="float" interfacename="thin_film_IOR" />
       <input name="normal" type="vector3" interfacename="normal" />

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -136,6 +136,7 @@ _BSDF_INPUTS = frozenset({
     "metalness",
     "specular", "specular_color", "specular_roughness",
     "specular_IOR", "specular_anisotropy",
+    "transmission", "transmission_color", "transmission_extra_roughness",
     "thin_film_thickness", "thin_film_IOR",
     "normal", "tangent",
 })
@@ -181,6 +182,7 @@ class TestStandardSurfaceDefault:
 
     # MaterialX GLSL enum constants (from mx_closure_type.glsl / pbrlib)
     _SCATTER_R = 0
+    _SCATTER_T = 1
     _DISTRIBUTION_GGX = 0
 
     _STDLIB_IMPORTS = (
@@ -310,10 +312,56 @@ class TestStandardSurfaceDefault:
                     + sh.bsdf.throughput * sh.one_minus_metalness
                 )
 
+                sh // ""
+                sh // "Transmission roughness"
+                sh.transmission_roughness_scalar = (
+                    (sh.specular_roughness + sh.transmission_extra_roughness)
+                    .clamp(0.0, 1.0)
+                )
+                sh.transmission_roughness = sh.Float2()
+                sh.mx_roughness_anisotropy(
+                    roughness=sh.transmission_roughness_scalar,
+                    anisotropy=sh.specular_anisotropy,
+                    out_=sh.transmission_roughness,
+                )
+
+                sh // ""
+                sh // "Transmission BSDF (dielectric transmission)"
+                sh.transmission_bsdf = sh.BSDF()
+                sh.transmission_bsdf.response = [0.0, 0.0, 0.0]
+                sh.transmission_bsdf.throughput = [1.0, 1.0, 1.0]
+                sh.mx_dielectric_bsdf(
+                    closureData=sh.closureData,
+                    weight=1.0,
+                    tint=sh.transmission_color,
+                    ior=sh.specular_IOR,
+                    roughness=sh.transmission_roughness,
+                    retroreflective=False,
+                    thinfilm_thickness=0.0,
+                    thinfilm_ior=1.5,
+                    normal=sh.normal,
+                    tangent=sh.tangent,
+                    distribution=self._DISTRIBUTION_GGX,
+                    scatter_mode=self._SCATTER_T,
+                    bsdf=sh.transmission_bsdf,
+                )
+
+                sh // ""
+                sh // "Transmission mix"
+                sh.one_minus_transmission = sh.Float(1) - sh.transmission
+                sh.bsdf.response = (
+                    sh.transmission_bsdf.response * sh.transmission
+                    + sh.bsdf.response * sh.one_minus_transmission
+                )
+                sh.bsdf.throughput = (
+                    sh.transmission_bsdf.throughput * sh.transmission
+                    + sh.bsdf.throughput * sh.one_minus_transmission
+                )
+
             test_ctx.add_node_impl(
                 func_name=self._FUNC_NAME,
                 mx_doc_string=(
                     "Metashade Standard Surface BSDF "
-                    "(diffuse + specular + conductor)"
+                    "(diffuse + specular + conductor + transmission)"
                 ),
             )

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -235,6 +235,52 @@ class TestStandardSurfaceDefault:
                 )
 
                 sh // ""
+                sh // "Transmission roughness"
+                sh.transmission_roughness_scalar = (
+                    (sh.specular_roughness + sh.transmission_extra_roughness)
+                    .clamp(0.0, 1.0)
+                )
+                sh.transmission_roughness = sh.Float2()
+                sh.mx_roughness_anisotropy(
+                    roughness=sh.transmission_roughness_scalar,
+                    anisotropy=sh.specular_anisotropy,
+                    out_=sh.transmission_roughness,
+                )
+
+                sh // ""
+                sh // "Transmission BSDF (dielectric transmission)"
+                sh.transmission_bsdf = sh.BSDF()
+                sh.transmission_bsdf.response = [0.0, 0.0, 0.0]
+                sh.transmission_bsdf.throughput = [1.0, 1.0, 1.0]
+                sh.mx_dielectric_bsdf(
+                    closureData=sh.closureData,
+                    weight=1.0,
+                    tint=sh.transmission_color,
+                    ior=sh.specular_IOR,
+                    roughness=sh.transmission_roughness,
+                    retroreflective=False,
+                    thinfilm_thickness=0.0,
+                    thinfilm_ior=1.5,
+                    normal=sh.normal,
+                    tangent=sh.tangent,
+                    distribution=self._DISTRIBUTION_GGX,
+                    scatter_mode=self._SCATTER_T,
+                    bsdf=sh.transmission_bsdf,
+                )
+
+                sh // ""
+                sh // "Transmission mix: blend transmission with diffuse"
+                sh.one_minus_transmission = sh.Float(1) - sh.transmission
+                sh.bsdf.response = (
+                    sh.transmission_bsdf.response * sh.transmission
+                    + sh.diffuse_bsdf.response * sh.one_minus_transmission
+                )
+                sh.bsdf.throughput = (
+                    sh.transmission_bsdf.throughput * sh.transmission
+                    + sh.diffuse_bsdf.throughput * sh.one_minus_transmission
+                )
+
+                sh // ""
                 sh // "Specular BSDF (dielectric reflection)"
                 sh.specular_bsdf = sh.BSDF()
                 sh.specular_bsdf.response = [0.0, 0.0, 0.0]
@@ -256,13 +302,13 @@ class TestStandardSurfaceDefault:
                 )
 
                 sh // ""
-                sh // "Layer: specular over diffuse"
+                sh // "Layer: specular over transmission mix"
                 sh.bsdf.response = (
                     sh.specular_bsdf.response
-                    + sh.diffuse_bsdf.response * sh.specular_bsdf.throughput
+                    + sh.bsdf.response * sh.specular_bsdf.throughput
                 )
                 sh.bsdf.throughput = (
-                    sh.specular_bsdf.throughput * sh.diffuse_bsdf.throughput
+                    sh.specular_bsdf.throughput * sh.bsdf.throughput
                 )
 
                 sh // ""
@@ -299,9 +345,9 @@ class TestStandardSurfaceDefault:
                 )
 
                 sh // ""
-                sh // "Metalness mix: conductor (fg) vs specular+diffuse (bg)"
+                sh // "Metalness mix: conductor (fg) vs specular layer (bg)"
                 sh // "Conductor response is already scaled by metalness (the weight),"
-                sh // "so we just add it to the attenuated dielectric+diffuse stack."
+                sh // "so we just add it to the attenuated specular layer."
                 sh.one_minus_metalness = sh.Float(1) - sh.metalness
                 sh.bsdf.response = (
                     sh.metal_bsdf.response
@@ -310,52 +356,6 @@ class TestStandardSurfaceDefault:
                 sh.bsdf.throughput = (
                     sh.metal_bsdf.throughput
                     + sh.bsdf.throughput * sh.one_minus_metalness
-                )
-
-                sh // ""
-                sh // "Transmission roughness"
-                sh.transmission_roughness_scalar = (
-                    (sh.specular_roughness + sh.transmission_extra_roughness)
-                    .clamp(0.0, 1.0)
-                )
-                sh.transmission_roughness = sh.Float2()
-                sh.mx_roughness_anisotropy(
-                    roughness=sh.transmission_roughness_scalar,
-                    anisotropy=sh.specular_anisotropy,
-                    out_=sh.transmission_roughness,
-                )
-
-                sh // ""
-                sh // "Transmission BSDF (dielectric transmission)"
-                sh.transmission_bsdf = sh.BSDF()
-                sh.transmission_bsdf.response = [0.0, 0.0, 0.0]
-                sh.transmission_bsdf.throughput = [1.0, 1.0, 1.0]
-                sh.mx_dielectric_bsdf(
-                    closureData=sh.closureData,
-                    weight=1.0,
-                    tint=sh.transmission_color,
-                    ior=sh.specular_IOR,
-                    roughness=sh.transmission_roughness,
-                    retroreflective=False,
-                    thinfilm_thickness=0.0,
-                    thinfilm_ior=1.5,
-                    normal=sh.normal,
-                    tangent=sh.tangent,
-                    distribution=self._DISTRIBUTION_GGX,
-                    scatter_mode=self._SCATTER_T,
-                    bsdf=sh.transmission_bsdf,
-                )
-
-                sh // ""
-                sh // "Transmission mix"
-                sh.one_minus_transmission = sh.Float(1) - sh.transmission
-                sh.bsdf.response = (
-                    sh.transmission_bsdf.response * sh.transmission
-                    + sh.bsdf.response * sh.one_minus_transmission
-                )
-                sh.bsdf.throughput = (
-                    sh.transmission_bsdf.throughput * sh.transmission
-                    + sh.bsdf.throughput * sh.one_minus_transmission
                 )
 
             test_ctx.add_node_impl(

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <nodedef name="ND_metashade_standard_surface_bsdf" node="metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + specular + conductor)">
+  <nodedef name="ND_metashade_standard_surface_bsdf" node="metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + specular + conductor + transmission)">
     <input name="base" type="float" doc="Input parameter base" />
     <input name="base_color" type="color3" doc="Input parameter base_color" />
     <input name="diffuse_roughness" type="float" doc="Input parameter diffuse_roughness" />
@@ -10,6 +10,9 @@
     <input name="specular_roughness" type="float" doc="Input parameter specular_roughness" />
     <input name="specular_IOR" type="float" doc="Input parameter specular_IOR" />
     <input name="specular_anisotropy" type="float" doc="Input parameter specular_anisotropy" />
+    <input name="transmission" type="float" doc="Input parameter transmission" />
+    <input name="transmission_color" type="color3" doc="Input parameter transmission_color" />
+    <input name="transmission_extra_roughness" type="float" doc="Input parameter transmission_extra_roughness" />
     <input name="thin_film_thickness" type="float" doc="Input parameter thin_film_thickness" />
     <input name="thin_film_IOR" type="float" doc="Input parameter thin_film_IOR" />
     <input name="normal" type="vector3" doc="Input parameter normal" />

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -3,7 +3,7 @@
 #include "mx_dielectric_bsdf.glsl"
 #include "mx_conductor_bsdf.glsl"
 #include "mx_artistic_ior.glsl"
-void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
+void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float transmission, vec3 transmission_color, float transmission_extra_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
 {
 	// 
 	// Roughness
@@ -45,5 +45,21 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	float one_minus_metalness = 1 - metalness;
 	bsdf.response = metal_bsdf.response + (bsdf.response * one_minus_metalness);
 	bsdf.throughput = metal_bsdf.throughput + (bsdf.throughput * one_minus_metalness);
+	// 
+	// Transmission roughness
+	float transmission_roughness_scalar = clamp(specular_roughness + transmission_extra_roughness, 0.0, 1.0);
+	vec2 transmission_roughness;
+	mx_roughness_anisotropy(transmission_roughness_scalar, specular_anisotropy, transmission_roughness);
+	// 
+	// Transmission BSDF (dielectric transmission)
+	BSDF transmission_bsdf;
+	transmission_bsdf.response = vec3(0.0, 0.0, 0.0);
+	transmission_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, tangent, 0, 1, transmission_bsdf);
+	// 
+	// Transmission mix
+	float one_minus_transmission = 1 - transmission;
+	bsdf.response = (transmission_bsdf.response * transmission) + (bsdf.response * one_minus_transmission);
+	bsdf.throughput = (transmission_bsdf.throughput * transmission) + (bsdf.throughput * one_minus_transmission);
 }
 

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -16,15 +16,31 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	diffuse_bsdf.throughput = vec3(1.0, 1.0, 1.0);
 	mx_oren_nayar_diffuse_bsdf(closureData, base, base_color, diffuse_roughness, normal, true, diffuse_bsdf);
 	// 
+	// Transmission roughness
+	float transmission_roughness_scalar = clamp(specular_roughness + transmission_extra_roughness, 0.0, 1.0);
+	vec2 transmission_roughness;
+	mx_roughness_anisotropy(transmission_roughness_scalar, specular_anisotropy, transmission_roughness);
+	// 
+	// Transmission BSDF (dielectric transmission)
+	BSDF transmission_bsdf;
+	transmission_bsdf.response = vec3(0.0, 0.0, 0.0);
+	transmission_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, tangent, 0, 1, transmission_bsdf);
+	// 
+	// Transmission mix: blend transmission with diffuse
+	float one_minus_transmission = 1 - transmission;
+	bsdf.response = (transmission_bsdf.response * transmission) + (diffuse_bsdf.response * one_minus_transmission);
+	bsdf.throughput = (transmission_bsdf.throughput * transmission) + (diffuse_bsdf.throughput * one_minus_transmission);
+	// 
 	// Specular BSDF (dielectric reflection)
 	BSDF specular_bsdf;
 	specular_bsdf.response = vec3(0.0, 0.0, 0.0);
 	specular_bsdf.throughput = vec3(1.0, 1.0, 1.0);
 	mx_dielectric_bsdf(closureData, specular, specular_color, specular_IOR, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, tangent, 0, 0, specular_bsdf);
 	// 
-	// Layer: specular over diffuse
-	bsdf.response = specular_bsdf.response + (diffuse_bsdf.response * specular_bsdf.throughput);
-	bsdf.throughput = specular_bsdf.throughput * diffuse_bsdf.throughput;
+	// Layer: specular over transmission mix
+	bsdf.response = specular_bsdf.response + (bsdf.response * specular_bsdf.throughput);
+	bsdf.throughput = specular_bsdf.throughput * bsdf.throughput;
 	// 
 	// Artistic IOR (reflectivity/edge-color -> physical IOR/extinction)
 	vec3 metal_reflectivity = base_color * base;
@@ -39,27 +55,11 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	metal_bsdf.throughput = vec3(1.0, 1.0, 1.0);
 	mx_conductor_bsdf(closureData, metalness, ior_n, ior_k, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, tangent, 0, metal_bsdf);
 	// 
-	// Metalness mix: conductor (fg) vs specular+diffuse (bg)
+	// Metalness mix: conductor (fg) vs specular layer (bg)
 	// Conductor response is already scaled by metalness (the weight),
-	// so we just add it to the attenuated dielectric+diffuse stack.
+	// so we just add it to the attenuated specular layer.
 	float one_minus_metalness = 1 - metalness;
 	bsdf.response = metal_bsdf.response + (bsdf.response * one_minus_metalness);
 	bsdf.throughput = metal_bsdf.throughput + (bsdf.throughput * one_minus_metalness);
-	// 
-	// Transmission roughness
-	float transmission_roughness_scalar = clamp(specular_roughness + transmission_extra_roughness, 0.0, 1.0);
-	vec2 transmission_roughness;
-	mx_roughness_anisotropy(transmission_roughness_scalar, specular_anisotropy, transmission_roughness);
-	// 
-	// Transmission BSDF (dielectric transmission)
-	BSDF transmission_bsdf;
-	transmission_bsdf.response = vec3(0.0, 0.0, 0.0);
-	transmission_bsdf.throughput = vec3(1.0, 1.0, 1.0);
-	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, tangent, 0, 1, transmission_bsdf);
-	// 
-	// Transmission mix
-	float one_minus_transmission = 1 - transmission;
-	bsdf.response = (transmission_bsdf.response * transmission) + (bsdf.response * one_minus_transmission);
-	bsdf.throughput = (transmission_bsdf.throughput * transmission) + (bsdf.throughput * one_minus_transmission);
 }
 

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.mtlx
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.mtlx
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <implementation name="IM_metashade_standard_surface_bsdf_genglsl" nodedef="ND_metashade_standard_surface_bsdf" target="genglsl" file="mx_metashade_standard_surface_bsdf_genglsl_impl.glsl" function="mx_metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + specular + conductor)" />
+  <implementation name="IM_metashade_standard_surface_bsdf_genglsl" nodedef="ND_metashade_standard_surface_bsdf" target="genglsl" file="mx_metashade_standard_surface_bsdf_genglsl_impl.glsl" function="mx_metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + specular + conductor + transmission)" />
 </materialx>


### PR DESCRIPTION
## Summary
- Add `dielectric_bsdf` with `scatter_mode=T` for transmission, including clamped transmission roughness.
- Restructure the BSDF layering to match the reference nodegraph: transmission mixed with diffuse first, then specular layered over the result. This preserves specular highlights on glass materials.
- Forward `transmission`, `transmission_color`, `transmission_extra_roughness` inputs through the thin nodegraph.

## Test plan
- [x] `test_mtlx_standard_surface.py::TestStandardSurfaceDefault` passes
- [x] Generated GLSL baseline updated and verified