### PR TITLE
Add tangent rotation to Standard Surface BSDF

### DIFF
--- a/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
+++ b/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
@@ -19,6 +19,7 @@
       <input name="specular_IOR" type="float" interfacename="specular_IOR" />
       <input name="metalness" type="float" interfacename="metalness" />
       <input name="specular_anisotropy" type="float" interfacename="specular_anisotropy" />
+      <input name="specular_rotation" type="float" interfacename="specular_rotation" />
       <input name="transmission" type="float" interfacename="transmission" />
       <input name="transmission_color" type="color3" interfacename="transmission_color" />
       <input name="transmission_extra_roughness" type="float" interfacename="transmission_extra_roughness" />

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -135,7 +135,7 @@ _BSDF_INPUTS = frozenset({
     "base", "base_color", "diffuse_roughness",
     "metalness",
     "specular", "specular_color", "specular_roughness",
-    "specular_IOR", "specular_anisotropy",
+    "specular_IOR", "specular_anisotropy", "specular_rotation",
     "transmission", "transmission_color", "transmission_extra_roughness",
     "thin_film_thickness", "thin_film_IOR",
     "normal", "tangent",
@@ -187,6 +187,7 @@ class TestStandardSurfaceDefault:
 
     _STDLIB_IMPORTS = (
         "roughness_anisotropy",
+        "rotate3d_vector3",
         "oren_nayar_diffuse_bsdf",
         "dielectric_bsdf",
         "conductor_bsdf",
@@ -218,6 +219,20 @@ class TestStandardSurfaceDefault:
                     anisotropy=sh.specular_anisotropy,
                     out_=sh.main_roughness,
                 )
+
+                sh // ""
+                sh // "Tangent rotation"
+                sh.main_tangent = sh.tangent
+                with sh.if_(sh.specular_anisotropy > 0.0):
+                    sh.tangent_rotate_degree = sh.specular_rotation * 360.0
+                    sh.tangent_rotated = sh.Float3()
+                    sh.mx_rotate_vector3(
+                        in_=sh.tangent,
+                        amount=sh.tangent_rotate_degree,
+                        axis=sh.normal,
+                        out_=sh.tangent_rotated,
+                    )
+                    sh.main_tangent = sh.tangent_rotated.normalize()
 
                 sh // ""
                 sh // "Diffuse BSDF (Oren-Nayar)"
@@ -262,7 +277,7 @@ class TestStandardSurfaceDefault:
                     thinfilm_thickness=0.0,
                     thinfilm_ior=1.5,
                     normal=sh.normal,
-                    tangent=sh.tangent,
+                    tangent=sh.main_tangent,
                     distribution=self._DISTRIBUTION_GGX,
                     scatter_mode=self._SCATTER_T,
                     bsdf=sh.transmission_bsdf,
@@ -295,7 +310,7 @@ class TestStandardSurfaceDefault:
                     thinfilm_thickness=sh.thin_film_thickness,
                     thinfilm_ior=sh.thin_film_IOR,
                     normal=sh.normal,
-                    tangent=sh.tangent,
+                    tangent=sh.main_tangent,
                     distribution=self._DISTRIBUTION_GGX,
                     scatter_mode=self._SCATTER_R,
                     bsdf=sh.specular_bsdf,
@@ -339,7 +354,7 @@ class TestStandardSurfaceDefault:
                     thinfilm_thickness=sh.thin_film_thickness,
                     thinfilm_ior=sh.thin_film_IOR,
                     normal=sh.normal,
-                    tangent=sh.tangent,
+                    tangent=sh.main_tangent,
                     distribution=self._DISTRIBUTION_GGX,
                     bsdf=sh.metal_bsdf,
                 )

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
@@ -10,6 +10,7 @@
     <input name="specular_roughness" type="float" doc="Input parameter specular_roughness" />
     <input name="specular_IOR" type="float" doc="Input parameter specular_IOR" />
     <input name="specular_anisotropy" type="float" doc="Input parameter specular_anisotropy" />
+    <input name="specular_rotation" type="float" doc="Input parameter specular_rotation" />
     <input name="transmission" type="float" doc="Input parameter transmission" />
     <input name="transmission_color" type="color3" doc="Input parameter transmission_color" />
     <input name="transmission_extra_roughness" type="float" doc="Input parameter transmission_extra_roughness" />

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -13,7 +13,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	// 
 	// Tangent rotation
 	vec3 main_tangent = tangent;
-	if (specular_anisotropy)
+	if (specular_anisotropy > 0.0)
 	{
 		float tangent_rotate_degree = specular_rotation * 360.0;
 		vec3 tangent_rotated;

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -1,14 +1,25 @@
 #include "mx_roughness_anisotropy.glsl"
+#include "mx_rotate_vector3.glsl"
 #include "mx_oren_nayar_diffuse_bsdf.glsl"
 #include "mx_dielectric_bsdf.glsl"
 #include "mx_conductor_bsdf.glsl"
 #include "mx_artistic_ior.glsl"
-void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float transmission, vec3 transmission_color, float transmission_extra_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
+void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
 {
 	// 
 	// Roughness
 	vec2 main_roughness;
 	mx_roughness_anisotropy(specular_roughness, specular_anisotropy, main_roughness);
+	// 
+	// Tangent rotation
+	vec3 main_tangent = tangent;
+	if (specular_anisotropy)
+	{
+		float tangent_rotate_degree = specular_rotation * 360.0;
+		vec3 tangent_rotated;
+		mx_rotate_vector3(tangent, tangent_rotate_degree, normal, tangent_rotated);
+		main_tangent = normalize(tangent_rotated);
+	}
 	// 
 	// Diffuse BSDF (Oren-Nayar)
 	BSDF diffuse_bsdf;
@@ -25,7 +36,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	BSDF transmission_bsdf;
 	transmission_bsdf.response = vec3(0.0, 0.0, 0.0);
 	transmission_bsdf.throughput = vec3(1.0, 1.0, 1.0);
-	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, tangent, 0, 1, transmission_bsdf);
+	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, main_tangent, 0, 1, transmission_bsdf);
 	// 
 	// Transmission mix: blend transmission with diffuse
 	float one_minus_transmission = 1 - transmission;
@@ -36,7 +47,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	BSDF specular_bsdf;
 	specular_bsdf.response = vec3(0.0, 0.0, 0.0);
 	specular_bsdf.throughput = vec3(1.0, 1.0, 1.0);
-	mx_dielectric_bsdf(closureData, specular, specular_color, specular_IOR, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, tangent, 0, 0, specular_bsdf);
+	mx_dielectric_bsdf(closureData, specular, specular_color, specular_IOR, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, main_tangent, 0, 0, specular_bsdf);
 	// 
 	// Layer: specular over transmission mix
 	bsdf.response = specular_bsdf.response + (bsdf.response * specular_bsdf.throughput);
@@ -53,7 +64,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	BSDF metal_bsdf;
 	metal_bsdf.response = vec3(0.0, 0.0, 0.0);
 	metal_bsdf.throughput = vec3(1.0, 1.0, 1.0);
-	mx_conductor_bsdf(closureData, metalness, ior_n, ior_k, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, tangent, 0, metal_bsdf);
+	mx_conductor_bsdf(closureData, metalness, ior_n, ior_k, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, main_tangent, 0, metal_bsdf);
 	// 
 	// Metalness mix: conductor (fg) vs specular layer (bg)
 	// Conductor response is already scaled by metalness (the weight),


### PR DESCRIPTION
## Summary

- Implements `specular_rotation` support in the Standard Surface BSDF: rotates the tangent vector by `specular_rotation * 360` degrees around the normal when `specular_anisotropy > 0.0`, using `mx_rotate_vector3` and `normalize`.
- Uses the new scalar comparison operators (#216) for the anisotropy guard (`sh.specular_anisotropy > 0.0`), replacing the previous f-string workaround.
- Updates GLSL baseline to reflect the proper `if (specular_anisotropy > 0.0)` condition.

## Test plan

- [x] Metashade internal baselines regenerated and match
- [x] All existing Metashade tests pass