### PR TITLE
Add sheen BSDF to Standard Surface

### DIFF
--- a/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
+++ b/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
@@ -5,7 +5,7 @@
     Wires the Metashade-generated metashade_standard_surface_bsdf node
     and standard-library emission and opacity nodes to the stock surface
     constructor.  Only the inputs consumed by existing nodes are forwarded;
-    unused SS inputs (coat, sheen, subsurface, etc.) are left unconnected.
+    unused SS inputs (coat, subsurface, etc.) are left unconnected.
   -->
   <nodegraph name="NG_metashade_standard_surface" nodedef="ND_standard_surface_surfaceshader">
 
@@ -20,6 +20,9 @@
       <input name="metalness" type="float" interfacename="metalness" />
       <input name="specular_anisotropy" type="float" interfacename="specular_anisotropy" />
       <input name="specular_rotation" type="float" interfacename="specular_rotation" />
+      <input name="sheen" type="float" interfacename="sheen" />
+      <input name="sheen_color" type="color3" interfacename="sheen_color" />
+      <input name="sheen_roughness" type="float" interfacename="sheen_roughness" />
       <input name="transmission" type="float" interfacename="transmission" />
       <input name="transmission_color" type="color3" interfacename="transmission_color" />
       <input name="transmission_extra_roughness" type="float" interfacename="transmission_extra_roughness" />

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -136,6 +136,7 @@ _BSDF_INPUTS = frozenset({
     "metalness",
     "specular", "specular_color", "specular_roughness",
     "specular_IOR", "specular_anisotropy", "specular_rotation",
+    "sheen", "sheen_color", "sheen_roughness",
     "transmission", "transmission_color", "transmission_extra_roughness",
     "thin_film_thickness", "thin_film_IOR",
     "normal", "tangent",
@@ -189,6 +190,7 @@ class TestStandardSurfaceDefault:
         "roughness_anisotropy",
         "rotate3d_vector3",
         "oren_nayar_diffuse_bsdf",
+        "sheen_bsdf",
         "dielectric_bsdf",
         "conductor_bsdf",
         "artistic_ior",
@@ -250,6 +252,31 @@ class TestStandardSurfaceDefault:
                 )
 
                 sh // ""
+                sh // "Sheen BSDF"
+                sh.sheen_bsdf_out = sh.BSDF()
+                sh.sheen_bsdf_out.response = [0.0, 0.0, 0.0]
+                sh.sheen_bsdf_out.throughput = [1.0, 1.0, 1.0]
+                sh.mx_sheen_bsdf(
+                    closureData=sh.closureData,
+                    weight=sh.sheen,
+                    color=sh.sheen_color,
+                    roughness=sh.sheen_roughness,
+                    normal=sh.normal,
+                    mode=0,
+                    bsdf=sh.sheen_bsdf_out,
+                )
+
+                sh // ""
+                sh // "Sheen layer: sheen over diffuse"
+                sh.bsdf.response = (
+                    sh.sheen_bsdf_out.response
+                    + sh.diffuse_bsdf.response * sh.sheen_bsdf_out.throughput
+                )
+                sh.bsdf.throughput = (
+                    sh.sheen_bsdf_out.throughput * sh.diffuse_bsdf.throughput
+                )
+
+                sh // ""
                 sh // "Transmission roughness"
                 sh.transmission_roughness_scalar = (
                     (sh.specular_roughness + sh.transmission_extra_roughness)
@@ -284,15 +311,15 @@ class TestStandardSurfaceDefault:
                 )
 
                 sh // ""
-                sh // "Transmission mix: blend transmission with diffuse"
+                sh // "Transmission mix: blend transmission with sheen layer"
                 sh.one_minus_transmission = sh.Float(1) - sh.transmission
                 sh.bsdf.response = (
                     sh.transmission_bsdf.response * sh.transmission
-                    + sh.diffuse_bsdf.response * sh.one_minus_transmission
+                    + sh.bsdf.response * sh.one_minus_transmission
                 )
                 sh.bsdf.throughput = (
                     sh.transmission_bsdf.throughput * sh.transmission
-                    + sh.diffuse_bsdf.throughput * sh.one_minus_transmission
+                    + sh.bsdf.throughput * sh.one_minus_transmission
                 )
 
                 sh // ""
@@ -377,6 +404,6 @@ class TestStandardSurfaceDefault:
                 func_name=self._FUNC_NAME,
                 mx_doc_string=(
                     "Metashade Standard Surface BSDF "
-                    "(diffuse + specular + conductor + transmission)"
+                    "(diffuse + sheen + specular + conductor + transmission)"
                 ),
             )

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <nodedef name="ND_metashade_standard_surface_bsdf" node="metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + specular + conductor + transmission)">
+  <nodedef name="ND_metashade_standard_surface_bsdf" node="metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + sheen + specular + conductor + transmission)">
     <input name="base" type="float" doc="Input parameter base" />
     <input name="base_color" type="color3" doc="Input parameter base_color" />
     <input name="diffuse_roughness" type="float" doc="Input parameter diffuse_roughness" />
@@ -14,6 +14,9 @@
     <input name="transmission" type="float" doc="Input parameter transmission" />
     <input name="transmission_color" type="color3" doc="Input parameter transmission_color" />
     <input name="transmission_extra_roughness" type="float" doc="Input parameter transmission_extra_roughness" />
+    <input name="sheen" type="float" doc="Input parameter sheen" />
+    <input name="sheen_color" type="color3" doc="Input parameter sheen_color" />
+    <input name="sheen_roughness" type="float" doc="Input parameter sheen_roughness" />
     <input name="thin_film_thickness" type="float" doc="Input parameter thin_film_thickness" />
     <input name="thin_film_IOR" type="float" doc="Input parameter thin_film_IOR" />
     <input name="normal" type="vector3" doc="Input parameter normal" />

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -1,10 +1,11 @@
 #include "mx_roughness_anisotropy.glsl"
 #include "mx_rotate_vector3.glsl"
 #include "mx_oren_nayar_diffuse_bsdf.glsl"
+#include "mx_sheen_bsdf.glsl"
 #include "mx_dielectric_bsdf.glsl"
 #include "mx_conductor_bsdf.glsl"
 #include "mx_artistic_ior.glsl"
-void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
+void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float sheen, vec3 sheen_color, float sheen_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
 {
 	// 
 	// Roughness
@@ -27,6 +28,16 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	diffuse_bsdf.throughput = vec3(1.0, 1.0, 1.0);
 	mx_oren_nayar_diffuse_bsdf(closureData, base, base_color, diffuse_roughness, normal, true, diffuse_bsdf);
 	// 
+	// Sheen BSDF
+	BSDF sheen_bsdf_out;
+	sheen_bsdf_out.response = vec3(0.0, 0.0, 0.0);
+	sheen_bsdf_out.throughput = vec3(1.0, 1.0, 1.0);
+	mx_sheen_bsdf(closureData, sheen, sheen_color, sheen_roughness, normal, 0, sheen_bsdf_out);
+	// 
+	// Sheen layer: sheen over diffuse
+	bsdf.response = sheen_bsdf_out.response + (diffuse_bsdf.response * sheen_bsdf_out.throughput);
+	bsdf.throughput = sheen_bsdf_out.throughput * diffuse_bsdf.throughput;
+	// 
 	// Transmission roughness
 	float transmission_roughness_scalar = clamp(specular_roughness + transmission_extra_roughness, 0.0, 1.0);
 	vec2 transmission_roughness;
@@ -38,10 +49,10 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	transmission_bsdf.throughput = vec3(1.0, 1.0, 1.0);
 	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, main_tangent, 0, 1, transmission_bsdf);
 	// 
-	// Transmission mix: blend transmission with diffuse
+	// Transmission mix: blend transmission with sheen layer
 	float one_minus_transmission = 1 - transmission;
-	bsdf.response = (transmission_bsdf.response * transmission) + (diffuse_bsdf.response * one_minus_transmission);
-	bsdf.throughput = (transmission_bsdf.throughput * transmission) + (diffuse_bsdf.throughput * one_minus_transmission);
+	bsdf.response = (transmission_bsdf.response * transmission) + (bsdf.response * one_minus_transmission);
+	bsdf.throughput = (transmission_bsdf.throughput * transmission) + (bsdf.throughput * one_minus_transmission);
 	// 
 	// Specular BSDF (dielectric reflection)
 	BSDF specular_bsdf;

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.mtlx
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.mtlx
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <implementation name="IM_metashade_standard_surface_bsdf_genglsl" nodedef="ND_metashade_standard_surface_bsdf" target="genglsl" file="mx_metashade_standard_surface_bsdf_genglsl_impl.glsl" function="mx_metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + specular + conductor + transmission)" />
+  <implementation name="IM_metashade_standard_surface_bsdf_genglsl" nodedef="ND_metashade_standard_surface_bsdf" target="genglsl" file="mx_metashade_standard_surface_bsdf_genglsl_impl.glsl" function="mx_metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + sheen + specular + conductor + transmission)" />
 </materialx>


### PR DESCRIPTION
## Summary

- Adds `sheen_bsdf` (Conty-Kulla model) layered over diffuse, before the transmission mix, matching the reference Standard Surface layering order.
- Forwards `sheen`, `sheen_color`, `sheen_roughness` inputs in the thin nodegraph.
- Updates generated baselines (nodedef, GLSL impl).

## Test plan

- [x] Metashade internal baselines regenerated and match
- [x] All existing Metashade tests pass