### PR TITLE
Add GLSL lerp intrinsic and fix return type for both backends

### DIFF
--- a/metashade/targets/glsl/_intrinsics.py
+++ b/metashade/targets/glsl/_intrinsics.py
@@ -38,6 +38,13 @@ class FloatIntrinsicsMixin:
             f'pow({self}, {y})'
         )
 
+    def lerp(self, a, b):
+        """Linear interpolation: mix(a, b, self)."""
+        return self._sh._instantiate_dtype(
+            a.__class__,
+            f'mix({a}, {b}, {self})'
+        )
+
     def saturate(self):
         """Clamp value to range [0, 1]. GLSL polyfill using clamp."""
         return self.clamp(0.0, 1.0)

--- a/metashade/targets/hlsl/sm6/dtypes.py
+++ b/metashade/targets/hlsl/sm6/dtypes.py
@@ -21,6 +21,9 @@ class _AnyLayoutMixin(
     _auto_float_intrinsics.AnyLayoutMixin,
     _auto_numeric_intrinsics.AnyLayoutMixin
 ):
+    def lerp(self, a, b):
+        return self._sh._instantiate_dtype(a.__class__, f'lerp({a}, {b}, {self})')
+
     def _checkDdxDdy(self, name):
         if not self._sh.__class__._is_pixel_shader:
             raise RuntimeError(f'"{name}" is only supported in pixel shaders')

--- a/tests/test_intrinsics.py
+++ b/tests/test_intrinsics.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from metashade.util.testing import ctx_cls_hg, HlslTestContext
+from metashade.util.testing import ctx_cls_hg, HlslTestContext, GlslTestContext
 import _auto_float_intrinsics, _auto_numeric_intrinsics
 
 class TestIntrinsics:
@@ -40,3 +40,51 @@ class TestIntrinsics:
 
     def test_numeric_intrinsics(self):
         self._test(_auto_numeric_intrinsics)
+
+
+class TestLerpReturnType:
+    """lerp must return the type of the interpolated values, not the weight."""
+
+    @ctx_cls_hg
+    def test_scalar_lerp_scalar(self, ctx_cls):
+        """float.lerp(float, float) returns float."""
+        with ctx_cls(no_file=True) as sh:
+            sh.uniform('g_t', sh.Float)
+            sh.uniform('g_a', sh.Float)
+            sh.uniform('g_b', sh.Float)
+            result = sh.g_t.lerp(sh.g_a, sh.g_b)
+            assert isinstance(result, sh.Float._get_dtype())
+
+    @ctx_cls_hg
+    def test_scalar_lerp_vec3(self, ctx_cls):
+        """float.lerp(Float3, Float3) returns Float3, not Float."""
+        with ctx_cls(no_file=True) as sh:
+            sh.uniform('g_t', sh.Float)
+            sh.uniform('g_a', sh.Float3)
+            sh.uniform('g_b', sh.Float3)
+            result = sh.g_t.lerp(sh.g_a, sh.g_b)
+            assert isinstance(result, sh.Float3._get_dtype())
+
+    @ctx_cls_hg
+    def test_scalar_lerp_vec4(self, ctx_cls):
+        """float.lerp(Float4, Float4) returns Float4."""
+        with ctx_cls(no_file=True) as sh:
+            sh.uniform('g_t', sh.Float)
+            sh.uniform('g_a', sh.Float4)
+            sh.uniform('g_b', sh.Float4)
+            result = sh.g_t.lerp(sh.g_a, sh.g_b)
+            assert isinstance(result, sh.Float4._get_dtype())
+
+    @ctx_cls_hg
+    def test_lerp_expression_string(self, ctx_cls):
+        """lerp emits the correct intrinsic call."""
+        with ctx_cls(no_file=True) as sh:
+            sh.uniform('g_t', sh.Float)
+            sh.uniform('g_a', sh.Float3)
+            sh.uniform('g_b', sh.Float3)
+            result = sh.g_t.lerp(sh.g_a, sh.g_b)
+            result_str = str(result)
+            if isinstance(ctx_cls(), HlslTestContext):
+                assert result_str == 'lerp(g_a, g_b, g_t)'
+            else:
+                assert result_str == 'mix(g_a, g_b, g_t)'


### PR DESCRIPTION
## Summary

- Adds `lerp(a, b)` to GLSL `FloatIntrinsicsMixin`, emitting `mix(a, b, self)`.
- Overrides the auto-generated HLSL `lerp` in `_AnyLayoutMixin` to fix the return type: uses `a.__class__` instead of `self.__class__` so `float.lerp(vec3, vec3)` correctly returns `vec3`.
- Adds regression tests for cross-type lerp return values and expression string verification (both HLSL and GLSL).

See #220 for excluding `lerp` from the auto-generated intrinsics.

## Test plan

- [x] All 10 intrinsics tests pass (HLSL + GLSL)
- [x] All 186 existing tests pass