### PR TITLE
Use lerp for transmission mix in Standard Surface

### DIFF
--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -312,14 +312,11 @@ class TestStandardSurfaceDefault:
 
                 sh // ""
                 sh // "Transmission mix: blend transmission with sheen layer"
-                sh.one_minus_transmission = sh.Float(1) - sh.transmission
-                sh.bsdf.response = (
-                    sh.transmission_bsdf.response * sh.transmission
-                    + sh.bsdf.response * sh.one_minus_transmission
+                sh.bsdf.response = sh.transmission.lerp(
+                    sh.bsdf.response, sh.transmission_bsdf.response
                 )
-                sh.bsdf.throughput = (
-                    sh.transmission_bsdf.throughput * sh.transmission
-                    + sh.bsdf.throughput * sh.one_minus_transmission
+                sh.bsdf.throughput = sh.transmission.lerp(
+                    sh.bsdf.throughput, sh.transmission_bsdf.throughput
                 )
 
                 sh // ""

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -50,9 +50,8 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, main_tangent, 0, 1, transmission_bsdf);
 	// 
 	// Transmission mix: blend transmission with sheen layer
-	float one_minus_transmission = 1 - transmission;
-	bsdf.response = (transmission_bsdf.response * transmission) + (bsdf.response * one_minus_transmission);
-	bsdf.throughput = (transmission_bsdf.throughput * transmission) + (bsdf.throughput * one_minus_transmission);
+	bsdf.response = mix(bsdf.response, transmission_bsdf.response, transmission);
+	bsdf.throughput = mix(bsdf.throughput, transmission_bsdf.throughput, transmission);
 	// 
 	// Specular BSDF (dielectric reflection)
 	BSDF specular_bsdf;


### PR DESCRIPTION
## Summary
- Replace manual `a * (1-t) + b * t` arithmetic in the transmission mix with the `lerp` intrinsic, which emits GLSL `mix()` directly
- Removes the `one_minus_transmission` intermediate variable
- Net -4 lines in the BSDF function body

Depends on #221 (lerp intrinsic fix) and #222 (sheen).

## Test plan
- [x] `test_generate_bsdf` passes
- [x] GLSL baseline updated — `mix()` calls replace manual arithmetic