### PR TITLE
Add coat to Standard Surface BSDF

### DIFF
--- a/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
+++ b/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
@@ -5,7 +5,7 @@
     Wires the Metashade-generated metashade_standard_surface_bsdf node
     and standard-library emission and opacity nodes to the stock surface
     constructor.  Only the inputs consumed by existing nodes are forwarded;
-    unused SS inputs (coat, subsurface, etc.) are left unconnected.
+    unused SS inputs (subsurface, etc.) are left unconnected.
   -->
   <nodegraph name="NG_metashade_standard_surface" nodedef="ND_standard_surface_surfaceshader">
 
@@ -23,6 +23,15 @@
       <input name="sheen" type="float" interfacename="sheen" />
       <input name="sheen_color" type="color3" interfacename="sheen_color" />
       <input name="sheen_roughness" type="float" interfacename="sheen_roughness" />
+      <input name="coat" type="float" interfacename="coat" />
+      <input name="coat_color" type="color3" interfacename="coat_color" />
+      <input name="coat_roughness" type="float" interfacename="coat_roughness" />
+      <input name="coat_anisotropy" type="float" interfacename="coat_anisotropy" />
+      <input name="coat_rotation" type="float" interfacename="coat_rotation" />
+      <input name="coat_IOR" type="float" interfacename="coat_IOR" />
+      <input name="coat_normal" type="vector3" interfacename="coat_normal" />
+      <input name="coat_affect_color" type="float" interfacename="coat_affect_color" />
+      <input name="coat_affect_roughness" type="float" interfacename="coat_affect_roughness" />
       <input name="transmission" type="float" interfacename="transmission" />
       <input name="transmission_color" type="color3" interfacename="transmission_color" />
       <input name="transmission_extra_roughness" type="float" interfacename="transmission_extra_roughness" />

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -137,6 +137,9 @@ _BSDF_INPUTS = frozenset({
     "specular", "specular_color", "specular_roughness",
     "specular_IOR", "specular_anisotropy", "specular_rotation",
     "sheen", "sheen_color", "sheen_roughness",
+    "coat", "coat_color", "coat_roughness", "coat_anisotropy",
+    "coat_rotation", "coat_IOR", "coat_normal",
+    "coat_affect_color", "coat_affect_roughness",
     "transmission", "transmission_color", "transmission_extra_roughness",
     "thin_film_thickness", "thin_film_IOR",
     "normal", "tangent",
@@ -214,10 +217,20 @@ class TestStandardSurfaceDefault:
 
             with sh.function(self._FUNC_NAME)(**params):
                 sh // ""
+                sh // "Coat affect roughness: blend specular roughness toward 1.0"
+                sh.coat_roughness_factor = (
+                    sh.coat_affect_roughness * sh.coat * sh.coat_roughness
+                )
+                sh.coat_affected_specular_roughness = (
+                    sh.specular_roughness * (sh.Float(1) - sh.coat_roughness_factor)
+                    + sh.coat_roughness_factor
+                )
+
+                sh // ""
                 sh // "Roughness"
                 sh.main_roughness = sh.Float2()
                 sh.mx_roughness_anisotropy(
-                    roughness=sh.specular_roughness,
+                    roughness=sh.coat_affected_specular_roughness,
                     anisotropy=sh.specular_anisotropy,
                     out_=sh.main_roughness,
                 )
@@ -237,6 +250,27 @@ class TestStandardSurfaceDefault:
                     sh.main_tangent = sh.tangent_rotated.normalize()
 
                 sh // ""
+                sh // "Coat tangent rotation"
+                sh.coat_tangent = sh.tangent
+                with sh.if_(sh.coat_anisotropy > 0.0):
+                    sh.coat_tangent_rotate_degree = sh.coat_rotation * 360.0
+                    sh.coat_tangent_rotated = sh.Float3()
+                    sh.mx_rotate_vector3(
+                        in_=sh.tangent,
+                        amount=sh.coat_tangent_rotate_degree,
+                        axis=sh.coat_normal,
+                        out_=sh.coat_tangent_rotated,
+                    )
+                    sh.coat_tangent = sh.coat_tangent_rotated.normalize()
+
+                sh // ""
+                sh // "Coat affect color: darken diffuse under the coat"
+                sh.coat_gamma = sh.coat.clamp(0.0, 1.0) * sh.coat_affect_color + 1.0
+                sh.coat_affected_diffuse_color = (
+                    sh.base_color.clamp(0.0, 1.0).pow(sh.coat_gamma)
+                )
+
+                sh // ""
                 sh // "Diffuse BSDF (Oren-Nayar)"
                 sh.diffuse_bsdf = sh.BSDF()
                 sh.diffuse_bsdf.response = [0.0, 0.0, 0.0]
@@ -244,7 +278,7 @@ class TestStandardSurfaceDefault:
                 sh.mx_oren_nayar_diffuse_bsdf(
                     closureData=sh.closureData,
                     weight=sh.base,
-                    color=sh.base_color,
+                    color=sh.coat_affected_diffuse_color,
                     roughness=sh.diffuse_roughness,
                     normal=sh.normal,
                     energy_compensation=True,
@@ -277,10 +311,15 @@ class TestStandardSurfaceDefault:
                 )
 
                 sh // ""
-                sh // "Transmission roughness"
-                sh.transmission_roughness_scalar = (
+                sh // "Transmission roughness (coat-affected)"
+                sh.transmission_roughness_clamped = (
                     (sh.specular_roughness + sh.transmission_extra_roughness)
                     .clamp(0.0, 1.0)
+                )
+                sh.transmission_roughness_scalar = (
+                    sh.transmission_roughness_clamped
+                    * (sh.Float(1) - sh.coat_roughness_factor)
+                    + sh.coat_roughness_factor
                 )
                 sh.transmission_roughness = sh.Float2()
                 sh.mx_roughness_anisotropy(
@@ -397,10 +436,58 @@ class TestStandardSurfaceDefault:
                     + sh.bsdf.throughput * sh.one_minus_metalness
                 )
 
+                sh // ""
+                sh // "Coat attenuation: tint underlying layers by coat color"
+                sh // "Float3 coercion needed: RgbF lerp result -> Float3 for BSDF multiply"
+                sh.coat_attenuation = sh.Float3(
+                    sh.coat.lerp(sh.RgbF(1.0), sh.coat_color)
+                )
+                sh.bsdf.response = sh.bsdf.response * sh.coat_attenuation
+                sh.bsdf.throughput = sh.bsdf.throughput * sh.coat_attenuation
+
+                sh // ""
+                sh // "Coat roughness"
+                sh.coat_roughness_vec = sh.Float2()
+                sh.mx_roughness_anisotropy(
+                    roughness=sh.coat_roughness,
+                    anisotropy=sh.coat_anisotropy,
+                    out_=sh.coat_roughness_vec,
+                )
+
+                sh // ""
+                sh // "Coat BSDF (dielectric reflection)"
+                sh.coat_bsdf = sh.BSDF()
+                sh.coat_bsdf.response = [0.0, 0.0, 0.0]
+                sh.coat_bsdf.throughput = [1.0, 1.0, 1.0]
+                sh.mx_dielectric_bsdf(
+                    closureData=sh.closureData,
+                    weight=sh.coat,
+                    tint=[1.0, 1.0, 1.0],
+                    ior=sh.coat_IOR,
+                    roughness=sh.coat_roughness_vec,
+                    retroreflective=False,
+                    thinfilm_thickness=0.0,
+                    thinfilm_ior=1.5,
+                    normal=sh.coat_normal,
+                    tangent=sh.coat_tangent,
+                    distribution=self._DISTRIBUTION_GGX,
+                    scatter_mode=self._SCATTER_R,
+                    bsdf=sh.coat_bsdf,
+                )
+
+                sh // ""
+                sh // "Coat layer: coat over attenuated base"
+                sh.bsdf.response = (
+                    sh.coat_bsdf.response
+                    + sh.bsdf.response * sh.coat_bsdf.throughput
+                )
+                sh.bsdf.throughput = (
+                    sh.coat_bsdf.throughput * sh.bsdf.throughput
+                )
+
             test_ctx.add_node_impl(
                 func_name=self._FUNC_NAME,
                 mx_doc_string=(
-                    "Metashade Standard Surface BSDF "
-                    "(diffuse + sheen + specular + conductor + transmission)"
+                    "Metashade Standard Surface BSDF"
                 ),
             )

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -265,6 +265,7 @@ class TestStandardSurfaceDefault:
 
                 sh // ""
                 sh // "Coat affect color: darken diffuse under the coat"
+                # RgbF workaround: exponent is unitless, not a color (#224)
                 sh.coat_gamma = sh.RgbF(
                     sh.coat.clamp(0.0, 1.0) * sh.coat_affect_color + 1.0
                 )

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -265,7 +265,9 @@ class TestStandardSurfaceDefault:
 
                 sh // ""
                 sh // "Coat affect color: darken diffuse under the coat"
-                sh.coat_gamma = sh.coat.clamp(0.0, 1.0) * sh.coat_affect_color + 1.0
+                sh.coat_gamma = sh.RgbF(
+                    sh.coat.clamp(0.0, 1.0) * sh.coat_affect_color + 1.0
+                )
                 sh.coat_affected_diffuse_color = (
                     sh.base_color.clamp(0.0, 1.0).pow(sh.coat_gamma)
                 )

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <nodedef name="ND_metashade_standard_surface_bsdf" node="metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + sheen + specular + conductor + transmission)">
+  <nodedef name="ND_metashade_standard_surface_bsdf" node="metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF">
     <input name="base" type="float" doc="Input parameter base" />
     <input name="base_color" type="color3" doc="Input parameter base_color" />
     <input name="diffuse_roughness" type="float" doc="Input parameter diffuse_roughness" />
@@ -17,6 +17,15 @@
     <input name="sheen" type="float" doc="Input parameter sheen" />
     <input name="sheen_color" type="color3" doc="Input parameter sheen_color" />
     <input name="sheen_roughness" type="float" doc="Input parameter sheen_roughness" />
+    <input name="coat" type="float" doc="Input parameter coat" />
+    <input name="coat_color" type="color3" doc="Input parameter coat_color" />
+    <input name="coat_roughness" type="float" doc="Input parameter coat_roughness" />
+    <input name="coat_anisotropy" type="float" doc="Input parameter coat_anisotropy" />
+    <input name="coat_rotation" type="float" doc="Input parameter coat_rotation" />
+    <input name="coat_IOR" type="float" doc="Input parameter coat_IOR" />
+    <input name="coat_normal" type="vector3" doc="Input parameter coat_normal" />
+    <input name="coat_affect_color" type="float" doc="Input parameter coat_affect_color" />
+    <input name="coat_affect_roughness" type="float" doc="Input parameter coat_affect_roughness" />
     <input name="thin_film_thickness" type="float" doc="Input parameter thin_film_thickness" />
     <input name="thin_film_IOR" type="float" doc="Input parameter thin_film_IOR" />
     <input name="normal" type="vector3" doc="Input parameter normal" />

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -37,7 +37,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	}
 	// 
 	// Coat affect color: darken diffuse under the coat
-	float coat_gamma = (clamp(coat, 0.0, 1.0) * coat_affect_color) + 1.0;
+	vec3 coat_gamma = vec3((clamp(coat, 0.0, 1.0) * coat_affect_color) + 1.0);
 	vec3 coat_affected_diffuse_color = pow(clamp(base_color, 0.0, 1.0), coat_gamma);
 	// 
 	// Diffuse BSDF (Oren-Nayar)

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -5,12 +5,16 @@
 #include "mx_dielectric_bsdf.glsl"
 #include "mx_conductor_bsdf.glsl"
 #include "mx_artistic_ior.glsl"
-void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float sheen, vec3 sheen_color, float sheen_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
+void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float sheen, vec3 sheen_color, float sheen_roughness, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
 {
+	// 
+	// Coat affect roughness: blend specular roughness toward 1.0
+	float coat_roughness_factor = (coat_affect_roughness * coat) * coat_roughness;
+	float coat_affected_specular_roughness = (specular_roughness * (1 - coat_roughness_factor)) + coat_roughness_factor;
 	// 
 	// Roughness
 	vec2 main_roughness;
-	mx_roughness_anisotropy(specular_roughness, specular_anisotropy, main_roughness);
+	mx_roughness_anisotropy(coat_affected_specular_roughness, specular_anisotropy, main_roughness);
 	// 
 	// Tangent rotation
 	vec3 main_tangent = tangent;
@@ -22,11 +26,25 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 		main_tangent = normalize(tangent_rotated);
 	}
 	// 
+	// Coat tangent rotation
+	vec3 coat_tangent = tangent;
+	if (coat_anisotropy > 0.0)
+	{
+		float coat_tangent_rotate_degree = coat_rotation * 360.0;
+		vec3 coat_tangent_rotated;
+		mx_rotate_vector3(tangent, coat_tangent_rotate_degree, coat_normal, coat_tangent_rotated);
+		coat_tangent = normalize(coat_tangent_rotated);
+	}
+	// 
+	// Coat affect color: darken diffuse under the coat
+	float coat_gamma = (clamp(coat, 0.0, 1.0) * coat_affect_color) + 1.0;
+	vec3 coat_affected_diffuse_color = pow(clamp(base_color, 0.0, 1.0), coat_gamma);
+	// 
 	// Diffuse BSDF (Oren-Nayar)
 	BSDF diffuse_bsdf;
 	diffuse_bsdf.response = vec3(0.0, 0.0, 0.0);
 	diffuse_bsdf.throughput = vec3(1.0, 1.0, 1.0);
-	mx_oren_nayar_diffuse_bsdf(closureData, base, base_color, diffuse_roughness, normal, true, diffuse_bsdf);
+	mx_oren_nayar_diffuse_bsdf(closureData, base, coat_affected_diffuse_color, diffuse_roughness, normal, true, diffuse_bsdf);
 	// 
 	// Sheen BSDF
 	BSDF sheen_bsdf_out;
@@ -38,8 +56,9 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	bsdf.response = sheen_bsdf_out.response + (diffuse_bsdf.response * sheen_bsdf_out.throughput);
 	bsdf.throughput = sheen_bsdf_out.throughput * diffuse_bsdf.throughput;
 	// 
-	// Transmission roughness
-	float transmission_roughness_scalar = clamp(specular_roughness + transmission_extra_roughness, 0.0, 1.0);
+	// Transmission roughness (coat-affected)
+	float transmission_roughness_clamped = clamp(specular_roughness + transmission_extra_roughness, 0.0, 1.0);
+	float transmission_roughness_scalar = (transmission_roughness_clamped * (1 - coat_roughness_factor)) + coat_roughness_factor;
 	vec2 transmission_roughness;
 	mx_roughness_anisotropy(transmission_roughness_scalar, specular_anisotropy, transmission_roughness);
 	// 
@@ -82,5 +101,25 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	float one_minus_metalness = 1 - metalness;
 	bsdf.response = metal_bsdf.response + (bsdf.response * one_minus_metalness);
 	bsdf.throughput = metal_bsdf.throughput + (bsdf.throughput * one_minus_metalness);
+	// 
+	// Coat attenuation: tint underlying layers by coat color
+	// Float3 coercion needed: RgbF lerp result -> Float3 for BSDF multiply
+	vec3 coat_attenuation = mix(vec3(1.0), coat_color, coat);
+	bsdf.response = bsdf.response * coat_attenuation;
+	bsdf.throughput = bsdf.throughput * coat_attenuation;
+	// 
+	// Coat roughness
+	vec2 coat_roughness_vec;
+	mx_roughness_anisotropy(coat_roughness, coat_anisotropy, coat_roughness_vec);
+	// 
+	// Coat BSDF (dielectric reflection)
+	BSDF coat_bsdf;
+	coat_bsdf.response = vec3(0.0, 0.0, 0.0);
+	coat_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	mx_dielectric_bsdf(closureData, coat, vec3(1.0, 1.0, 1.0), coat_IOR, coat_roughness_vec, false, 0.0, 1.5, coat_normal, coat_tangent, 0, 0, coat_bsdf);
+	// 
+	// Coat layer: coat over attenuated base
+	bsdf.response = coat_bsdf.response + (bsdf.response * coat_bsdf.throughput);
+	bsdf.throughput = coat_bsdf.throughput * bsdf.throughput;
 }
 

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.mtlx
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.mtlx
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <implementation name="IM_metashade_standard_surface_bsdf_genglsl" nodedef="ND_metashade_standard_surface_bsdf" target="genglsl" file="mx_metashade_standard_surface_bsdf_genglsl_impl.glsl" function="mx_metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF (diffuse + sheen + specular + conductor + transmission)" />
+  <implementation name="IM_metashade_standard_surface_bsdf_genglsl" nodedef="ND_metashade_standard_surface_bsdf" target="genglsl" file="mx_metashade_standard_surface_bsdf_genglsl_impl.glsl" function="mx_metashade_standard_surface_bsdf" doc="Metashade Standard Surface BSDF" />
 </materialx>


### PR DESCRIPTION
## Summary

- Implements the full coat component of the MaterialX Standard Surface
- Coat affect roughness: blend specular/transmission roughness toward 1.0
- Coat affect color: darken diffuse via `pow(base_color, gamma)` (see #224 for type workaround)
- Coat tangent rotation (independent of specular rotation)
- Coat attenuation: tint underlying layers via `lerp(white, coat_color, coat)` with `Float3(RgbF)` coercion
- Coat BSDF: `dielectric_bsdf` with `coat_IOR`, layered over attenuated base
- All 9 coat inputs forwarded in the thin nodegraph

## Test plan

- [x] `test_generate_bsdf` passes
- [x] MaterialX render tests pass for all 11 Standard Surface materials including carpaint