### PR TITLE
Add subsurface scattering to Standard Surface BSDF

### DIFF
--- a/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
+++ b/tests/mtlx/libraries/standard_surface/mx_metashade_standard_surface_surfaceshader.mtlx
@@ -5,7 +5,7 @@
     Wires the Metashade-generated metashade_standard_surface_bsdf node
     and standard-library emission and opacity nodes to the stock surface
     constructor.  Only the inputs consumed by existing nodes are forwarded;
-    unused SS inputs (subsurface, etc.) are left unconnected.
+    unused SS inputs (advanced transmission, etc.) are left unconnected.
   -->
   <nodegraph name="NG_metashade_standard_surface" nodedef="ND_standard_surface_surfaceshader">
 
@@ -32,6 +32,12 @@
       <input name="coat_normal" type="vector3" interfacename="coat_normal" />
       <input name="coat_affect_color" type="float" interfacename="coat_affect_color" />
       <input name="coat_affect_roughness" type="float" interfacename="coat_affect_roughness" />
+      <input name="subsurface" type="float" interfacename="subsurface" />
+      <input name="subsurface_color" type="color3" interfacename="subsurface_color" />
+      <input name="subsurface_radius" type="color3" interfacename="subsurface_radius" />
+      <input name="subsurface_scale" type="float" interfacename="subsurface_scale" />
+      <input name="subsurface_anisotropy" type="float" interfacename="subsurface_anisotropy" />
+      <input name="thin_walled" type="boolean" interfacename="thin_walled" />
       <input name="transmission" type="float" interfacename="transmission" />
       <input name="transmission_color" type="color3" interfacename="transmission_color" />
       <input name="transmission_extra_roughness" type="float" interfacename="transmission_extra_roughness" />

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -140,6 +140,9 @@ _BSDF_INPUTS = frozenset({
     "coat", "coat_color", "coat_roughness", "coat_anisotropy",
     "coat_rotation", "coat_IOR", "coat_normal",
     "coat_affect_color", "coat_affect_roughness",
+    "subsurface", "subsurface_color", "subsurface_radius",
+    "subsurface_scale", "subsurface_anisotropy",
+    "thin_walled",
     "transmission", "transmission_color", "transmission_extra_roughness",
     "thin_film_thickness", "thin_film_IOR",
     "normal", "tangent",
@@ -193,6 +196,8 @@ class TestStandardSurfaceDefault:
         "roughness_anisotropy",
         "rotate3d_vector3",
         "oren_nayar_diffuse_bsdf",
+        "translucent_bsdf",
+        "subsurface_bsdf",
         "sheen_bsdf",
         "dielectric_bsdf",
         "conductor_bsdf",
@@ -274,6 +279,13 @@ class TestStandardSurfaceDefault:
                 )
 
                 sh // ""
+                sh // "Coat affect subsurface color"
+                # RgbF workaround: exponent is unitless, not a color (#224)
+                sh.coat_affected_subsurface_color = (
+                    sh.subsurface_color.clamp(0.0, 1.0).pow(sh.coat_gamma)
+                )
+
+                sh // ""
                 sh // "Diffuse BSDF (Oren-Nayar)"
                 sh.diffuse_bsdf = sh.BSDF()
                 sh.diffuse_bsdf.response = [0.0, 0.0, 0.0]
@@ -286,6 +298,41 @@ class TestStandardSurfaceDefault:
                     normal=sh.normal,
                     energy_compensation=True,
                     bsdf=sh.diffuse_bsdf,
+                )
+
+                sh // ""
+                sh // "Subsurface scattering"
+                sh.subsurface_radius_scaled = sh.subsurface_radius * sh.subsurface_scale
+                sh.sss_bsdf = sh.BSDF()
+                sh.sss_bsdf.response = [0.0, 0.0, 0.0]
+                sh.sss_bsdf.throughput = [1.0, 1.0, 1.0]
+                with sh.if_(sh.thin_walled):
+                    sh.mx_translucent_bsdf(
+                        closureData=sh.closureData,
+                        weight=1.0,
+                        color=sh.coat_affected_subsurface_color,
+                        normal=sh.normal,
+                        bsdf=sh.sss_bsdf,
+                    )
+                with sh.else_():
+                    sh.mx_subsurface_bsdf(
+                        closureData=sh.closureData,
+                        weight=1.0,
+                        color=sh.coat_affected_subsurface_color,
+                        radius=sh.subsurface_radius_scaled,
+                        anisotropy=sh.subsurface_anisotropy,
+                        normal=sh.normal,
+                        bsdf=sh.sss_bsdf,
+                    )
+
+                sh // ""
+                sh // "Subsurface mix: blend SSS with diffuse"
+                sh.subsurface_mix = sh.BSDF()
+                sh.subsurface_mix.response = sh.subsurface.lerp(
+                    sh.diffuse_bsdf.response, sh.sss_bsdf.response
+                )
+                sh.subsurface_mix.throughput = sh.subsurface.lerp(
+                    sh.diffuse_bsdf.throughput, sh.sss_bsdf.throughput
                 )
 
                 sh // ""
@@ -304,13 +351,13 @@ class TestStandardSurfaceDefault:
                 )
 
                 sh // ""
-                sh // "Sheen layer: sheen over diffuse"
+                sh // "Sheen layer: sheen over subsurface mix"
                 sh.bsdf.response = (
                     sh.sheen_bsdf_out.response
-                    + sh.diffuse_bsdf.response * sh.sheen_bsdf_out.throughput
+                    + sh.subsurface_mix.response * sh.sheen_bsdf_out.throughput
                 )
                 sh.bsdf.throughput = (
-                    sh.sheen_bsdf_out.throughput * sh.diffuse_bsdf.throughput
+                    sh.sheen_bsdf_out.throughput * sh.subsurface_mix.throughput
                 )
 
                 sh // ""

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_defs.mtlx
@@ -14,6 +14,11 @@
     <input name="transmission" type="float" doc="Input parameter transmission" />
     <input name="transmission_color" type="color3" doc="Input parameter transmission_color" />
     <input name="transmission_extra_roughness" type="float" doc="Input parameter transmission_extra_roughness" />
+    <input name="subsurface" type="float" doc="Input parameter subsurface" />
+    <input name="subsurface_color" type="color3" doc="Input parameter subsurface_color" />
+    <input name="subsurface_radius" type="color3" doc="Input parameter subsurface_radius" />
+    <input name="subsurface_scale" type="float" doc="Input parameter subsurface_scale" />
+    <input name="subsurface_anisotropy" type="float" doc="Input parameter subsurface_anisotropy" />
     <input name="sheen" type="float" doc="Input parameter sheen" />
     <input name="sheen_color" type="color3" doc="Input parameter sheen_color" />
     <input name="sheen_roughness" type="float" doc="Input parameter sheen_roughness" />
@@ -28,6 +33,7 @@
     <input name="coat_affect_roughness" type="float" doc="Input parameter coat_affect_roughness" />
     <input name="thin_film_thickness" type="float" doc="Input parameter thin_film_thickness" />
     <input name="thin_film_IOR" type="float" doc="Input parameter thin_film_IOR" />
+    <input name="thin_walled" type="boolean" doc="Input parameter thin_walled" />
     <input name="normal" type="vector3" doc="Input parameter normal" />
     <input name="tangent" type="vector3" doc="Input parameter tangent" />
     <output name="bsdf" type="BSDF" doc="Output parameter bsdf" />

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -1,11 +1,13 @@
 #include "mx_roughness_anisotropy.glsl"
 #include "mx_rotate_vector3.glsl"
 #include "mx_oren_nayar_diffuse_bsdf.glsl"
+#include "mx_translucent_bsdf.glsl"
+#include "mx_subsurface_bsdf.glsl"
 #include "mx_sheen_bsdf.glsl"
 #include "mx_dielectric_bsdf.glsl"
 #include "mx_conductor_bsdf.glsl"
 #include "mx_artistic_ior.glsl"
-void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float sheen, vec3 sheen_color, float sheen_roughness, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
+void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, bool thin_walled, vec3 normal, vec3 tangent, inout BSDF bsdf)
 {
 	// 
 	// Coat affect roughness: blend specular roughness toward 1.0
@@ -40,11 +42,33 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	vec3 coat_gamma = vec3((clamp(coat, 0.0, 1.0) * coat_affect_color) + 1.0);
 	vec3 coat_affected_diffuse_color = pow(clamp(base_color, 0.0, 1.0), coat_gamma);
 	// 
+	// Coat affect subsurface color
+	vec3 coat_affected_subsurface_color = pow(clamp(subsurface_color, 0.0, 1.0), coat_gamma);
+	// 
 	// Diffuse BSDF (Oren-Nayar)
 	BSDF diffuse_bsdf;
 	diffuse_bsdf.response = vec3(0.0, 0.0, 0.0);
 	diffuse_bsdf.throughput = vec3(1.0, 1.0, 1.0);
 	mx_oren_nayar_diffuse_bsdf(closureData, base, coat_affected_diffuse_color, diffuse_roughness, normal, true, diffuse_bsdf);
+	// 
+	// Subsurface scattering
+	vec3 subsurface_radius_scaled = subsurface_radius * subsurface_scale;
+	BSDF sss_bsdf;
+	sss_bsdf.response = vec3(0.0, 0.0, 0.0);
+	sss_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	if (thin_walled)
+	{
+		mx_translucent_bsdf(closureData, 1.0, coat_affected_subsurface_color, normal, sss_bsdf);
+	}
+	else
+	{
+		mx_subsurface_bsdf(closureData, 1.0, coat_affected_subsurface_color, subsurface_radius_scaled, subsurface_anisotropy, normal, sss_bsdf);
+	}
+	// 
+	// Subsurface mix: blend SSS with diffuse
+	BSDF subsurface_mix;
+	subsurface_mix.response = mix(diffuse_bsdf.response, sss_bsdf.response, subsurface);
+	subsurface_mix.throughput = mix(diffuse_bsdf.throughput, sss_bsdf.throughput, subsurface);
 	// 
 	// Sheen BSDF
 	BSDF sheen_bsdf_out;
@@ -52,9 +76,9 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	sheen_bsdf_out.throughput = vec3(1.0, 1.0, 1.0);
 	mx_sheen_bsdf(closureData, sheen, sheen_color, sheen_roughness, normal, 0, sheen_bsdf_out);
 	// 
-	// Sheen layer: sheen over diffuse
-	bsdf.response = sheen_bsdf_out.response + (diffuse_bsdf.response * sheen_bsdf_out.throughput);
-	bsdf.throughput = sheen_bsdf_out.throughput * diffuse_bsdf.throughput;
+	// Sheen layer: sheen over subsurface mix
+	bsdf.response = sheen_bsdf_out.response + (subsurface_mix.response * sheen_bsdf_out.throughput);
+	bsdf.throughput = sheen_bsdf_out.throughput * subsurface_mix.throughput;
 	// 
 	// Transmission roughness (coat-affected)
 	float transmission_roughness_clamped = clamp(specular_roughness + transmission_extra_roughness, 0.0, 1.0);


### PR DESCRIPTION
## Summary

- Implements subsurface scattering for the MaterialX Standard Surface
- `thin_walled` boolean selects between `translucent_bsdf` (thin shell diffuse transmission) and `subsurface_bsdf` (volumetric Burley diffusion approximation)
- Subsurface color is coat-affected via `pow()`, same pattern as diffuse (see #224)
- Subsurface radius scaled by `subsurface_scale`
- `subsurface` weight mixes SSS with Oren-Nayar diffuse via `lerp`
- All 6 new inputs forwarded in the thin nodegraph

## Test plan

- [x] `test_generate_bsdf` passes
- [x] MaterialX render tests pass for all 11 existing Standard Surface materials (no regression)
- [x] `standard_surface_jade.mtlx` (`subsurface=0.4`) renders correctly, exercising the SSS path