### PR TITLE
Use Qualitative Oren-Nayar to match Standard Surface spec

### DIFF
--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -221,6 +221,8 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Diffuse BSDF (Oren-Nayar)"
+        sh // "`energy_compensation=false` to match the Standard Surface spec, "
+        sh // "instead of the more physically-correct `true` in OpenPBR"
         sh.diffuse_bsdf = sh.BSDF()
         sh.diffuse_bsdf.response = [0.0, 0.0, 0.0]
         sh.diffuse_bsdf.throughput = [1.0, 1.0, 1.0]
@@ -230,7 +232,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
             color=sh.coat_affected_diffuse_color,
             roughness=sh.diffuse_roughness,
             normal=sh.normal,
-            energy_compensation=True,
+            energy_compensation=False,
             bsdf=sh.diffuse_bsdf,
         )
 

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -46,10 +46,12 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	vec3 coat_affected_subsurface_color = pow(clamp(subsurface_color, 0.0, 1.0), coat_gamma);
 	// 
 	// Diffuse BSDF (Oren-Nayar)
+	// `energy_compensation=false` to match the Standard Surface spec, 
+	// instead of the more physically-correct `true` in OpenPBR
 	BSDF diffuse_bsdf;
 	diffuse_bsdf.response = vec3(0.0, 0.0, 0.0);
 	diffuse_bsdf.throughput = vec3(1.0, 1.0, 1.0);
-	mx_oren_nayar_diffuse_bsdf(closureData, base, coat_affected_diffuse_color, diffuse_roughness, normal, true, diffuse_bsdf);
+	mx_oren_nayar_diffuse_bsdf(closureData, base, coat_affected_diffuse_color, diffuse_roughness, normal, false, diffuse_bsdf);
 	// 
 	// Subsurface scattering
 	vec3 subsurface_radius_scaled = subsurface_radius * subsurface_scale;


### PR DESCRIPTION
## Summary

- Set `energy_compensation=false` on the diffuse BSDF to match the stock Standard Surface nodegraph (Qualitative Oren-Nayar)
- The energy-preserving EON model (`energy_compensation=true`) is used by OpenPBR but changes the look of SS materials with non-zero `diffuse_roughness`
- Fixes masonry FLIP threshold failure (0.073 > 0.05) caused by the brighter EON diffuse response

## Test plan

- [x] All 120 Metashade tests pass (232 subtests), including masonry which was previously excluded
- [ ] CI passes