### PR TITLE
mtlx: Standard Surface: Inline private rotate helper to avoid duplicate definitions

### DIFF
--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -54,7 +54,6 @@ _DISTRIBUTION_GGX = 0
 
 _STDLIB_IMPORTS = (
     "roughness_anisotropy",
-    "rotate3d_vector3",
     "oren_nayar_diffuse_bsdf",
     "translucent_bsdf",
     "subsurface_bsdf",
@@ -134,6 +133,29 @@ def _build_bsdf_params(sh, surfaceshader_nodedef):
     return params
 
 
+def _mx_metashade_rotate_vector3(
+    sh, in_: Float3, amount: Float, axis: Float3,
+    result: Out[Float3],
+):
+    """Rodrigues' rotation formula.
+
+    Private copy of the stdlib rotate3d helper.  Avoids
+    duplicate-definition errors when the material's own nodegraph
+    also uses rotate3d nodes, which would cause the generator to
+    emit mx_rotate_vector3 a second time
+    (see https://github.com/metashade/metashade/issues/230).
+    """
+    sh.axis_n = axis.normalize()
+    sh.rad = amount.radians()
+    sh.s = sh.rad.sin()
+    sh.c = sh.rad.cos()
+    result._ = (
+        in_ * sh.c
+        + in_.cross(sh.axis_n) * sh.s
+        + sh.axis_n * sh.axis_n.dot(in_) * (sh.Float(1) - sh.c)
+    )
+
+
 def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
     """Generate the Standard Surface BSDF source-code node.
 
@@ -147,6 +169,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
     register_mtlx_closure_structs(sh)
     _acquire_stdlib_sourcecode_nodes(sh, stdlib_doc, _STDLIB_IMPORTS)
+    sh.instantiate(_mx_metashade_rotate_vector3)
 
     surfaceshader_nodedef = stdlib_doc.getNodeDef(_SURFACESHADER_NODEDEF)
     assert surfaceshader_nodedef is not None, (
@@ -180,11 +203,11 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         with sh.if_(sh.specular_anisotropy > 0.0):
             sh.tangent_rotate_degree = sh.specular_rotation * 360.0
             sh.tangent_rotated = sh.Float3()
-            sh.mx_rotate_vector3(
+            sh._mx_metashade_rotate_vector3(
                 in_=sh.tangent,
                 amount=sh.tangent_rotate_degree,
                 axis=sh.normal,
-                out_=sh.tangent_rotated,
+                result=sh.tangent_rotated,
             )
             sh.main_tangent = sh.tangent_rotated.normalize()
 
@@ -194,11 +217,11 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         with sh.if_(sh.coat_anisotropy > 0.0):
             sh.coat_tangent_rotate_degree = sh.coat_rotation * 360.0
             sh.coat_tangent_rotated = sh.Float3()
-            sh.mx_rotate_vector3(
+            sh._mx_metashade_rotate_vector3(
                 in_=sh.tangent,
                 amount=sh.coat_tangent_rotate_degree,
                 axis=sh.coat_normal,
-                out_=sh.coat_tangent_rotated,
+                result=sh.coat_tangent_rotated,
             )
             sh.coat_tangent = sh.coat_tangent_rotated.normalize()
 

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -1,5 +1,4 @@
 #include "mx_roughness_anisotropy.glsl"
-#include "mx_rotate_vector3.glsl"
 #include "mx_oren_nayar_diffuse_bsdf.glsl"
 #include "mx_translucent_bsdf.glsl"
 #include "mx_subsurface_bsdf.glsl"
@@ -7,6 +6,23 @@
 #include "mx_dielectric_bsdf.glsl"
 #include "mx_conductor_bsdf.glsl"
 #include "mx_artistic_ior.glsl"
+// Rodrigues' rotation formula.
+// 
+// Private copy of the stdlib rotate3d helper.  Avoids
+// duplicate-definition errors when the material's own nodegraph
+// also uses rotate3d nodes, which would cause the generator to
+// emit mx_rotate_vector3 a second time
+// (see https://github.com/metashade/metashade/issues/230).
+//
+void _mx_metashade_rotate_vector3(vec3 in_, float amount, vec3 axis, out vec3 result)
+{
+	vec3 axis_n = normalize(axis);
+	float rad = radians(amount);
+	float s = sin(rad);
+	float c = cos(rad);
+	result = ((in_ * c) + (cross(in_, axis_n) * s)) + ((axis_n * dot(axis_n, in_)) * (1 - c));
+}
+
 void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, bool thin_walled, vec3 normal, vec3 tangent, inout BSDF bsdf)
 {
 	// 
@@ -24,7 +40,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	{
 		float tangent_rotate_degree = specular_rotation * 360.0;
 		vec3 tangent_rotated;
-		mx_rotate_vector3(tangent, tangent_rotate_degree, normal, tangent_rotated);
+		_mx_metashade_rotate_vector3(tangent, tangent_rotate_degree, normal, tangent_rotated);
 		main_tangent = normalize(tangent_rotated);
 	}
 	// 
@@ -34,7 +50,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	{
 		float coat_tangent_rotate_degree = coat_rotation * 360.0;
 		vec3 coat_tangent_rotated;
-		mx_rotate_vector3(tangent, coat_tangent_rotate_degree, coat_normal, coat_tangent_rotated);
+		_mx_metashade_rotate_vector3(tangent, coat_tangent_rotate_degree, coat_normal, coat_tangent_rotated);
 		coat_tangent = normalize(coat_tangent_rotated);
 	}
 	// 


### PR DESCRIPTION
## Summary

- Replaces the stdlib `rotate3d_vector3` `#include` with a private `_mx_metashade_rotate_vector3` helper using Rodrigues' rotation formula.
- Works around the MaterialX `SourceCodeNode` deduplication gap: when a material's nodegraph also uses `rotate3d` nodes, the generator emits `mx_rotate_vector3` a second time, causing GLSL compilation errors.
- Uses the `sh.instantiate()` decorator pattern with a docstring explaining the rationale.
- Depends on the GLSL intrinsics added in #231 (`sin`, `cos`, `radians`).

Workaround for https://github.com/metashade/metashade/issues/230

## Test plan

- [x] All 55 Metashade render tests pass (22 ASWF + 33 Adsk)
- [x] All 8 previously-excluded Adsk materials now enabled
- [ ] CI passes