### PR TITLE
Support one-line struct constructor initialization

### DIFF
--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -246,9 +246,9 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // "Diffuse BSDF (Oren-Nayar)"
         sh // "`energy_compensation=false` to match the Standard Surface spec, "
         sh // "instead of the more physically-correct `true` in OpenPBR"
-        sh.diffuse_bsdf = sh.BSDF()
-        sh.diffuse_bsdf.response = [0.0, 0.0, 0.0]
-        sh.diffuse_bsdf.throughput = [1.0, 1.0, 1.0]
+        sh.diffuse_bsdf = sh.BSDF(
+            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+        )
         sh.mx_oren_nayar_diffuse_bsdf(
             closureData=sh.closureData,
             weight=sh.base,
@@ -262,9 +262,9 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // ""
         sh // "Subsurface scattering"
         sh.subsurface_radius_scaled = sh.subsurface_radius * sh.subsurface_scale
-        sh.sss_bsdf = sh.BSDF()
-        sh.sss_bsdf.response = [0.0, 0.0, 0.0]
-        sh.sss_bsdf.throughput = [1.0, 1.0, 1.0]
+        sh.sss_bsdf = sh.BSDF(
+            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+        )
         with sh.if_(sh.thin_walled):
             sh.mx_translucent_bsdf(
                 closureData=sh.closureData,
@@ -296,9 +296,9 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Sheen BSDF"
-        sh.sheen_bsdf_out = sh.BSDF()
-        sh.sheen_bsdf_out.response = [0.0, 0.0, 0.0]
-        sh.sheen_bsdf_out.throughput = [1.0, 1.0, 1.0]
+        sh.sheen_bsdf_out = sh.BSDF(
+            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+        )
         sh.mx_sheen_bsdf(
             closureData=sh.closureData,
             weight=sh.sheen,
@@ -339,9 +339,9 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Transmission BSDF (dielectric transmission)"
-        sh.transmission_bsdf = sh.BSDF()
-        sh.transmission_bsdf.response = [0.0, 0.0, 0.0]
-        sh.transmission_bsdf.throughput = [1.0, 1.0, 1.0]
+        sh.transmission_bsdf = sh.BSDF(
+            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+        )
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,
             weight=1.0,
@@ -369,9 +369,9 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Specular BSDF (dielectric reflection)"
-        sh.specular_bsdf = sh.BSDF()
-        sh.specular_bsdf.response = [0.0, 0.0, 0.0]
-        sh.specular_bsdf.throughput = [1.0, 1.0, 1.0]
+        sh.specular_bsdf = sh.BSDF(
+            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+        )
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,
             weight=sh.specular,
@@ -413,9 +413,9 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Conductor BSDF (metal reflection)"
-        sh.metal_bsdf = sh.BSDF()
-        sh.metal_bsdf.response = [0.0, 0.0, 0.0]
-        sh.metal_bsdf.throughput = [1.0, 1.0, 1.0]
+        sh.metal_bsdf = sh.BSDF(
+            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+        )
         sh.mx_conductor_bsdf(
             closureData=sh.closureData,
             weight=sh.metalness,
@@ -465,9 +465,9 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Coat BSDF (dielectric reflection)"
-        sh.coat_bsdf = sh.BSDF()
-        sh.coat_bsdf.response = [0.0, 0.0, 0.0]
-        sh.coat_bsdf.throughput = [1.0, 1.0, 1.0]
+        sh.coat_bsdf = sh.BSDF(
+            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+        )
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,
             weight=sh.coat,

--- a/metashade/targets/_clike/generator.py
+++ b/metashade/targets/_clike/generator.py
@@ -19,6 +19,14 @@ import metashade.targets._base.generator as base
 from . import arrays, context, struct
 
 class Generator(base.Generator):
+    def _format_struct_ctor(self, type_name, member_strs):
+        """Format a struct constructor expression.
+
+        GLSL uses constructor syntax: ``TypeName(val1, val2)``.
+        HLSL overrides this to use aggregate initialization.
+        """
+        return f"{type_name}({', '.join(member_strs)})"
+
     def function(self, name : str, return_type = None):
         return context.FunctionDecl(self, name, return_type)
 

--- a/metashade/targets/_clike/struct.py
+++ b/metashade/targets/_clike/struct.py
@@ -64,7 +64,7 @@ class Struct(BaseType, StructBase):
                     ref = member_def.dtype(value)
                 member_refs.append(str(ref))
 
-            unknown = set(kwargs) - set(self.__class__._member_defs)
+            unknown = sorted(set(kwargs) - set(self.__class__._member_defs))
             if unknown:
                 raise TypeError(
                     f"{type_name}(): unknown members: {unknown}"

--- a/metashade/targets/_clike/struct.py
+++ b/metashade/targets/_clike/struct.py
@@ -49,9 +49,34 @@ class StructBase:
         return True
 
 class Struct(BaseType, StructBase):
-    def __init__(self, expression : str = None):
-        BaseType.__init__(self, expression)
-        StructBase.__init__(self, expression)
+    def __init__(self, expression : str = None, **kwargs):
+        if kwargs:
+            type_name = self.__class__._get_target_type_name()
+            member_refs = []
+            for member_name, member_def in self.__class__._member_defs.items():
+                if member_name not in kwargs:
+                    raise TypeError(
+                        f"{type_name}(): missing member '{member_name}'"
+                    )
+                value = kwargs[member_name]
+                ref = member_def.dtype._get_value_ref(value)
+                if ref is None:
+                    ref = member_def.dtype(value)
+                member_refs.append(str(ref))
+
+            unknown = set(kwargs) - set(self.__class__._member_defs)
+            if unknown:
+                raise TypeError(
+                    f"{type_name}(): unknown members: {unknown}"
+                )
+
+            sh = self.__class__._sh
+            ctor_expr = sh._format_struct_ctor(type_name, member_refs)
+            BaseType.__init__(self, ctor_expr)
+            StructBase.__init__(self, None)
+        else:
+            BaseType.__init__(self, expression)
+            StructBase.__init__(self, expression)
 
         self._sh = self.__class__._sh
         for member_name, member in vars(self).items():

--- a/metashade/targets/hlsl/sm6/generator_base.py
+++ b/metashade/targets/hlsl/sm6/generator_base.py
@@ -69,6 +69,10 @@ class _UniqueRegisterChecker(rtsl.UniqueKeyChecker):
 class Generator(rtsl.Generator, vk.GeneratorMixin):
     _is_pixel_shader = False
 
+    def _format_struct_ctor(self, type_name, member_strs):
+        members = ', '.join(member_strs)
+        return '{' + members + '}'
+
     def __init__(self, file_, matrix_post_multiplication = False):
         super().__init__(file_)
         vk.GeneratorMixin.__init__(self)

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -64,16 +64,12 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	// Diffuse BSDF (Oren-Nayar)
 	// `energy_compensation=false` to match the Standard Surface spec, 
 	// instead of the more physically-correct `true` in OpenPBR
-	BSDF diffuse_bsdf;
-	diffuse_bsdf.response = vec3(0.0, 0.0, 0.0);
-	diffuse_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	BSDF diffuse_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
 	mx_oren_nayar_diffuse_bsdf(closureData, base, coat_affected_diffuse_color, diffuse_roughness, normal, false, diffuse_bsdf);
 	// 
 	// Subsurface scattering
 	vec3 subsurface_radius_scaled = subsurface_radius * subsurface_scale;
-	BSDF sss_bsdf;
-	sss_bsdf.response = vec3(0.0, 0.0, 0.0);
-	sss_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	BSDF sss_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
 	if (thin_walled)
 	{
 		mx_translucent_bsdf(closureData, 1.0, coat_affected_subsurface_color, normal, sss_bsdf);
@@ -89,9 +85,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	subsurface_mix.throughput = mix(diffuse_bsdf.throughput, sss_bsdf.throughput, subsurface);
 	// 
 	// Sheen BSDF
-	BSDF sheen_bsdf_out;
-	sheen_bsdf_out.response = vec3(0.0, 0.0, 0.0);
-	sheen_bsdf_out.throughput = vec3(1.0, 1.0, 1.0);
+	BSDF sheen_bsdf_out = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
 	mx_sheen_bsdf(closureData, sheen, sheen_color, sheen_roughness, normal, 0, sheen_bsdf_out);
 	// 
 	// Sheen layer: sheen over subsurface mix
@@ -105,9 +99,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	mx_roughness_anisotropy(transmission_roughness_scalar, specular_anisotropy, transmission_roughness);
 	// 
 	// Transmission BSDF (dielectric transmission)
-	BSDF transmission_bsdf;
-	transmission_bsdf.response = vec3(0.0, 0.0, 0.0);
-	transmission_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	BSDF transmission_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
 	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, main_tangent, 0, 1, transmission_bsdf);
 	// 
 	// Transmission mix: blend transmission with sheen layer
@@ -115,9 +107,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	bsdf.throughput = mix(bsdf.throughput, transmission_bsdf.throughput, transmission);
 	// 
 	// Specular BSDF (dielectric reflection)
-	BSDF specular_bsdf;
-	specular_bsdf.response = vec3(0.0, 0.0, 0.0);
-	specular_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	BSDF specular_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
 	mx_dielectric_bsdf(closureData, specular, specular_color, specular_IOR, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, main_tangent, 0, 0, specular_bsdf);
 	// 
 	// Layer: specular over transmission mix
@@ -132,9 +122,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	mx_artistic_ior(metal_reflectivity, metal_edgecolor, ior_n, ior_k);
 	// 
 	// Conductor BSDF (metal reflection)
-	BSDF metal_bsdf;
-	metal_bsdf.response = vec3(0.0, 0.0, 0.0);
-	metal_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	BSDF metal_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
 	mx_conductor_bsdf(closureData, metalness, ior_n, ior_k, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, main_tangent, 0, metal_bsdf);
 	// 
 	// Metalness mix: conductor (fg) vs specular layer (bg)
@@ -155,9 +143,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	mx_roughness_anisotropy(coat_roughness, coat_anisotropy, coat_roughness_vec);
 	// 
 	// Coat BSDF (dielectric reflection)
-	BSDF coat_bsdf;
-	coat_bsdf.response = vec3(0.0, 0.0, 0.0);
-	coat_bsdf.throughput = vec3(1.0, 1.0, 1.0);
+	BSDF coat_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
 	mx_dielectric_bsdf(closureData, coat, vec3(1.0, 1.0, 1.0), coat_IOR, coat_roughness_vec, false, 0.0, 1.5, coat_normal, coat_tangent, 0, 0, coat_bsdf);
 	// 
 	// Coat layer: coat over attenuated base

--- a/tests/ref/test_struct_constructor_init.glsl
+++ b/tests/ref/test_struct_constructor_init.glsl
@@ -1,0 +1,29 @@
+#version 450
+layout (set = 0, binding = 0) uniform cb
+{
+	vec3 g_f3A;
+	vec3 g_f3B;
+};
+
+// The struct defined in the target language
+struct BSDF { vec3 response; vec3 throughput; };
+
+BSDF testConstructorInit(vec3 a, vec3 b)
+{
+	// Constructor-style initialization
+	BSDF result = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	// With lvalue members
+	BSDF from_args = BSDF(a, b);
+	// Overwrite a member after construction
+	result.response = from_args.response;
+	return result;
+}
+
+layout(location = 0) out vec4 out_f4Color;
+void main()
+{
+	BSDF bsdf = testConstructorInit(g_f3A, g_f3B);
+	vec4 final = vec4(bsdf.response + bsdf.throughput, 1.0);
+	out_f4Color = final;
+}
+

--- a/tests/ref/test_struct_constructor_init.hlsl
+++ b/tests/ref/test_struct_constructor_init.hlsl
@@ -1,0 +1,35 @@
+[[vk::binding(0, 0)]]
+cbuffer cb : register(b0)
+{
+	float3 g_f3A;
+	float3 g_f3B;
+};
+
+// The struct defined in the target language
+struct BSDF { float3 response; float3 throughput; };
+
+BSDF testConstructorInit(float3 a, float3 b)
+{
+	// Constructor-style initialization
+	BSDF result = {float3(0.0, 0.0, 0.0), float3(1.0, 1.0, 1.0)};
+	// With lvalue members
+	BSDF from_args = {a, b};
+	// Overwrite a member after construction
+	result.response = from_args.response;
+	return result;
+}
+
+struct PsOut
+{
+	float4 color : SV_TARGET;
+};
+
+PsOut main()
+{
+	BSDF bsdf = testConstructorInit(g_f3A, g_f3B);
+	float4 final = float4(bsdf.response + bsdf.throughput, 1.0);
+	PsOut out_struct;
+	out_struct.color = final;
+	return out_struct;
+}
+

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -121,6 +121,58 @@ class TestStructDefinition:
                     sh.out_f4Color = sh.final_color
 
     @ctx_cls_hg
+    def test_struct_constructor_init(self, ctx_cls):
+        """Test one-line struct initialization via kwargs."""
+        ctx = ctx_cls(dummy_entry_point = False)
+        with ctx as sh:
+            self._generate_test_uniforms(sh)
+
+            sh // 'The struct defined in the target language'
+            if isinstance(ctx, HlslTestContext):
+                sh._emit('struct BSDF { float3 response; float3 throughput; };\n\n')
+            else:
+                sh._emit('struct BSDF { vec3 response; vec3 throughput; };\n\n')
+
+            sh.struct('BSDF', emit = False)(
+                response = sh.Float3,
+                throughput = sh.Float3
+            )
+
+            with sh.function('testConstructorInit', sh.BSDF)(
+                a = sh.Float3, b = sh.Float3
+            ):
+                sh // 'Constructor-style initialization'
+                sh.result = sh.BSDF(
+                    response = [0.0, 0.0, 0.0],
+                    throughput = [1.0, 1.0, 1.0]
+                )
+
+                sh // 'With lvalue members'
+                sh.from_args = sh.BSDF(response = sh.a, throughput = sh.b)
+
+                sh // 'Overwrite a member after construction'
+                sh.result.response = sh.from_args.response
+
+                sh.return_(sh.result)
+
+            with self._generate_ps_main_decl(sh, ctx, sh.Float4):
+                sh.bsdf = sh.testConstructorInit(
+                    a = sh.g_f3A, b = sh.g_f3B
+                )
+
+                sh.final = sh.Float4(
+                    xyz = sh.bsdf.response + sh.bsdf.throughput,
+                    w = 1.0
+                )
+
+                if isinstance(ctx, HlslTestContext):
+                    sh.out_struct = sh.PsOut()
+                    sh.out_struct.color = sh.final
+                    sh.return_(sh.out_struct)
+                else:
+                    sh.out_f4Color = sh.final
+
+    @ctx_cls_hg
     def test_struct_emit_false_in_function(self, ctx_cls):
         """Test that acquired struct can be used as function return type."""
         ctx = ctx_cls(dummy_entry_point = False)


### PR DESCRIPTION
## Summary

- Add keyword-argument constructor syntax to struct types, enabling one-line initialization instead of three separate member assignments
- Generated code uses target-appropriate syntax: GLSL constructor calls (`BSDF(vec3(...), vec3(...))`) vs HLSL aggregate initialization (`{float3(...), float3(...)}`)
- Apply the new syntax to Standard Surface BSDF, replacing 7 verbose three-line zero-init blocks with concise one-liners

Ref: #209

## Test plan

- [x] New `test_struct_constructor_init` passes for both GLSL and HLSL targets
- [x] GLSL reference compiled with glslang
- [x] HLSL reference compiled with DXC
- [x] Full test suite passes (221 tests)
- [x] Standard Surface BSDF reference output regenerated and verified