### PR TITLE
Use scalar broadcast for BSDF struct initialization

### DIFF
--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -247,7 +247,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // "`energy_compensation=false` to match the Standard Surface spec, "
         sh // "instead of the more physically-correct `true` in OpenPBR"
         sh.diffuse_bsdf = sh.BSDF(
-            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+            response = sh.Float3(0), throughput = sh.Float3(1)
         )
         sh.mx_oren_nayar_diffuse_bsdf(
             closureData=sh.closureData,
@@ -263,7 +263,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // "Subsurface scattering"
         sh.subsurface_radius_scaled = sh.subsurface_radius * sh.subsurface_scale
         sh.sss_bsdf = sh.BSDF(
-            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+            response = sh.Float3(0), throughput = sh.Float3(1)
         )
         with sh.if_(sh.thin_walled):
             sh.mx_translucent_bsdf(
@@ -297,7 +297,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // ""
         sh // "Sheen BSDF"
         sh.sheen_bsdf_out = sh.BSDF(
-            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+            response = sh.Float3(0), throughput = sh.Float3(1)
         )
         sh.mx_sheen_bsdf(
             closureData=sh.closureData,
@@ -340,7 +340,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // ""
         sh // "Transmission BSDF (dielectric transmission)"
         sh.transmission_bsdf = sh.BSDF(
-            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+            response = sh.Float3(0), throughput = sh.Float3(1)
         )
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,
@@ -370,7 +370,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // ""
         sh // "Specular BSDF (dielectric reflection)"
         sh.specular_bsdf = sh.BSDF(
-            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+            response = sh.Float3(0), throughput = sh.Float3(1)
         )
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,
@@ -414,7 +414,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // ""
         sh // "Conductor BSDF (metal reflection)"
         sh.metal_bsdf = sh.BSDF(
-            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+            response = sh.Float3(0), throughput = sh.Float3(1)
         )
         sh.mx_conductor_bsdf(
             closureData=sh.closureData,
@@ -466,7 +466,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // ""
         sh // "Coat BSDF (dielectric reflection)"
         sh.coat_bsdf = sh.BSDF(
-            response = [0.0, 0.0, 0.0], throughput = [1.0, 1.0, 1.0]
+            response = sh.Float3(0), throughput = sh.Float3(1)
         )
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -64,12 +64,12 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	// Diffuse BSDF (Oren-Nayar)
 	// `energy_compensation=false` to match the Standard Surface spec, 
 	// instead of the more physically-correct `true` in OpenPBR
-	BSDF diffuse_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	BSDF diffuse_bsdf = BSDF(vec3(0), vec3(1));
 	mx_oren_nayar_diffuse_bsdf(closureData, base, coat_affected_diffuse_color, diffuse_roughness, normal, false, diffuse_bsdf);
 	// 
 	// Subsurface scattering
 	vec3 subsurface_radius_scaled = subsurface_radius * subsurface_scale;
-	BSDF sss_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	BSDF sss_bsdf = BSDF(vec3(0), vec3(1));
 	if (thin_walled)
 	{
 		mx_translucent_bsdf(closureData, 1.0, coat_affected_subsurface_color, normal, sss_bsdf);
@@ -85,7 +85,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	subsurface_mix.throughput = mix(diffuse_bsdf.throughput, sss_bsdf.throughput, subsurface);
 	// 
 	// Sheen BSDF
-	BSDF sheen_bsdf_out = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	BSDF sheen_bsdf_out = BSDF(vec3(0), vec3(1));
 	mx_sheen_bsdf(closureData, sheen, sheen_color, sheen_roughness, normal, 0, sheen_bsdf_out);
 	// 
 	// Sheen layer: sheen over subsurface mix
@@ -99,7 +99,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	mx_roughness_anisotropy(transmission_roughness_scalar, specular_anisotropy, transmission_roughness);
 	// 
 	// Transmission BSDF (dielectric transmission)
-	BSDF transmission_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	BSDF transmission_bsdf = BSDF(vec3(0), vec3(1));
 	mx_dielectric_bsdf(closureData, 1.0, transmission_color, specular_IOR, transmission_roughness, false, 0.0, 1.5, normal, main_tangent, 0, 1, transmission_bsdf);
 	// 
 	// Transmission mix: blend transmission with sheen layer
@@ -107,7 +107,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	bsdf.throughput = mix(bsdf.throughput, transmission_bsdf.throughput, transmission);
 	// 
 	// Specular BSDF (dielectric reflection)
-	BSDF specular_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	BSDF specular_bsdf = BSDF(vec3(0), vec3(1));
 	mx_dielectric_bsdf(closureData, specular, specular_color, specular_IOR, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, main_tangent, 0, 0, specular_bsdf);
 	// 
 	// Layer: specular over transmission mix
@@ -122,7 +122,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	mx_artistic_ior(metal_reflectivity, metal_edgecolor, ior_n, ior_k);
 	// 
 	// Conductor BSDF (metal reflection)
-	BSDF metal_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	BSDF metal_bsdf = BSDF(vec3(0), vec3(1));
 	mx_conductor_bsdf(closureData, metalness, ior_n, ior_k, main_roughness, false, thin_film_thickness, thin_film_IOR, normal, main_tangent, 0, metal_bsdf);
 	// 
 	// Metalness mix: conductor (fg) vs specular layer (bg)
@@ -143,7 +143,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	mx_roughness_anisotropy(coat_roughness, coat_anisotropy, coat_roughness_vec);
 	// 
 	// Coat BSDF (dielectric reflection)
-	BSDF coat_bsdf = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	BSDF coat_bsdf = BSDF(vec3(0), vec3(1));
 	mx_dielectric_bsdf(closureData, coat, vec3(1.0, 1.0, 1.0), coat_IOR, coat_roughness_vec, false, 0.0, 1.5, coat_normal, coat_tangent, 0, 0, coat_bsdf);
 	// 
 	// Coat layer: coat over attenuated base

--- a/tests/ref/test_struct_constructor_init.glsl
+++ b/tests/ref/test_struct_constructor_init.glsl
@@ -10,8 +10,8 @@ struct BSDF { vec3 response; vec3 throughput; };
 
 BSDF testConstructorInit(vec3 a, vec3 b)
 {
-	// Constructor-style initialization
-	BSDF result = BSDF(vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+	// Constructor-style initialization with scalar broadcast
+	BSDF result = BSDF(vec3(0), vec3(1));
 	// With lvalue members
 	BSDF from_args = BSDF(a, b);
 	// Overwrite a member after construction

--- a/tests/ref/test_struct_constructor_init.hlsl
+++ b/tests/ref/test_struct_constructor_init.hlsl
@@ -10,8 +10,8 @@ struct BSDF { float3 response; float3 throughput; };
 
 BSDF testConstructorInit(float3 a, float3 b)
 {
-	// Constructor-style initialization
-	BSDF result = {float3(0.0, 0.0, 0.0), float3(1.0, 1.0, 1.0)};
+	// Constructor-style initialization with scalar broadcast
+	BSDF result = {0.xxx, 1.xxx};
 	// With lvalue members
 	BSDF from_args = {a, b};
 	// Overwrite a member after construction

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -141,10 +141,10 @@ class TestStructDefinition:
             with sh.function('testConstructorInit', sh.BSDF)(
                 a = sh.Float3, b = sh.Float3
             ):
-                sh // 'Constructor-style initialization'
+                sh // 'Constructor-style initialization with scalar broadcast'
                 sh.result = sh.BSDF(
-                    response = [0.0, 0.0, 0.0],
-                    throughput = [1.0, 1.0, 1.0]
+                    response = sh.Float3(0),
+                    throughput = sh.Float3(1)
                 )
 
                 sh // 'With lvalue members'


### PR DESCRIPTION
## Summary

- Use `sh.Float3(0)` / `sh.Float3(1)` instead of `[0.0, 0.0, 0.0]` / `[1.0, 1.0, 1.0]` in struct constructor kwargs, leveraging the existing scalar broadcast support in both GLSL and HLSL vector types
- Produces more readable generated code: `vec3(0)` / `0.xxx` instead of `vec3(0.0, 0.0, 0.0)` / `0.0.xxx`
- Applied to all 7 BSDF zero-init sites in Standard Surface and to the struct constructor test

Ref: #209

## Test plan

- [x] `test_struct_constructor_init` updated and passes for both GLSL and HLSL
- [x] Standard Surface BSDF reference regenerated
- [x] Full test suite passes (221 tests)