### PR TITLE
Use Metashade struct emission in constructor init test

### DIFF
--- a/tests/ref/test_struct_constructor_init.glsl
+++ b/tests/ref/test_struct_constructor_init.glsl
@@ -5,8 +5,11 @@ layout (set = 0, binding = 0) uniform cb
 	vec3 g_f3B;
 };
 
-// The struct defined in the target language
-struct BSDF { vec3 response; vec3 throughput; };
+struct BSDF
+{
+	vec3 response;
+	vec3 throughput;
+};
 
 BSDF testConstructorInit(vec3 a, vec3 b)
 {

--- a/tests/ref/test_struct_constructor_init.hlsl
+++ b/tests/ref/test_struct_constructor_init.hlsl
@@ -5,8 +5,11 @@ cbuffer cb : register(b0)
 	float3 g_f3B;
 };
 
-// The struct defined in the target language
-struct BSDF { float3 response; float3 throughput; };
+struct BSDF
+{
+	float3 response;
+	float3 throughput;
+};
 
 BSDF testConstructorInit(float3 a, float3 b)
 {

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -127,13 +127,7 @@ class TestStructDefinition:
         with ctx as sh:
             self._generate_test_uniforms(sh)
 
-            sh // 'The struct defined in the target language'
-            if isinstance(ctx, HlslTestContext):
-                sh._emit('struct BSDF { float3 response; float3 throughput; };\n\n')
-            else:
-                sh._emit('struct BSDF { vec3 response; vec3 throughput; };\n\n')
-
-            sh.struct('BSDF', emit = False)(
+            sh.struct('BSDF')(
                 response = sh.Float3,
                 throughput = sh.Float3
             )


### PR DESCRIPTION
## Summary

- Replace raw `sh._emit()` of target-specific struct definitions with `sh.struct('BSDF')()`, letting Metashade emit the struct properly instead of hardcoding GLSL/HLSL syntax in the test

Ref: #209

## Test plan

- [x] Full test suite passes (221 tests)
- [x] Generated reference files use Metashade's multi-line struct format