### PR TITLE
Support default member values for struct types

### DIFF
--- a/metashade/mtlx/dtypes.py
+++ b/metashade/mtlx/dtypes.py
@@ -117,7 +117,7 @@ def register_mtlx_closure_structs(sh):
     )
     
     sh.struct('BSDF', emit=False)(
-        response=sh.Float3,
-        throughput=sh.Float3
+        response=(sh.Float3, 0),
+        throughput=(sh.Float3, 1)
     )
 

--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -246,9 +246,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // "Diffuse BSDF (Oren-Nayar)"
         sh // "`energy_compensation=false` to match the Standard Surface spec, "
         sh // "instead of the more physically-correct `true` in OpenPBR"
-        sh.diffuse_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
+        sh.diffuse_bsdf = sh.BSDF()
         sh.mx_oren_nayar_diffuse_bsdf(
             closureData=sh.closureData,
             weight=sh.base,
@@ -262,9 +260,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
         sh // ""
         sh // "Subsurface scattering"
         sh.subsurface_radius_scaled = sh.subsurface_radius * sh.subsurface_scale
-        sh.sss_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
+        sh.sss_bsdf = sh.BSDF()
         with sh.if_(sh.thin_walled):
             sh.mx_translucent_bsdf(
                 closureData=sh.closureData,
@@ -296,9 +292,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Sheen BSDF"
-        sh.sheen_bsdf_out = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
+        sh.sheen_bsdf_out = sh.BSDF()
         sh.mx_sheen_bsdf(
             closureData=sh.closureData,
             weight=sh.sheen,
@@ -339,9 +333,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Transmission BSDF (dielectric transmission)"
-        sh.transmission_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
+        sh.transmission_bsdf = sh.BSDF()
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,
             weight=1.0,
@@ -369,9 +361,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Specular BSDF (dielectric reflection)"
-        sh.specular_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
+        sh.specular_bsdf = sh.BSDF()
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,
             weight=sh.specular,
@@ -413,9 +403,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Conductor BSDF (metal reflection)"
-        sh.metal_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
+        sh.metal_bsdf = sh.BSDF()
         sh.mx_conductor_bsdf(
             closureData=sh.closureData,
             weight=sh.metalness,
@@ -465,9 +453,7 @@ def generate(ctx: GlslGeneratorContext, stdlib_doc: mx.Document):
 
         sh // ""
         sh // "Coat BSDF (dielectric reflection)"
-        sh.coat_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
+        sh.coat_bsdf = sh.BSDF()
         sh.mx_dielectric_bsdf(
             closureData=sh.closureData,
             weight=sh.coat,

--- a/metashade/targets/_clike/context.py
+++ b/metashade/targets/_clike/context.py
@@ -106,8 +106,8 @@ class FunctionDecl:
             else:
                 self._sh._emit(', ')
 
-            # Create a temporary instance using the dtype factory
-            param_instance = param.dtype_factory()
+            # Create an uninitialized instance (None suppresses defaults)
+            param_instance = param.dtype_factory(None)
             param_instance._define(
                 self._sh,
                 name,
@@ -194,7 +194,7 @@ class FunctionDef:
         # Create parameter instances from dtype factories
         self._parameters = {}
         for param_name, param_def in param_defs.items():
-            param_instance = param_def.dtype_factory()
+            param_instance = param_def.dtype_factory(None)
             # Bind the parameter instance to its name and generator
             param_instance._bind(sh, param_name, allow_init=False)
             self._parameters[param_name] = param_instance

--- a/metashade/targets/_clike/struct.py
+++ b/metashade/targets/_clike/struct.py
@@ -14,10 +14,14 @@
 
 from metashade.targets._clike.dtypes import BaseType
 
+_NO_DEFAULT = object()
+_NO_EXPRESSION = object()
+
 class StructMemberDef:
-    def __init__(self, dtype, semantic = None):
+    def __init__(self, dtype, semantic=None, default=_NO_DEFAULT):
         self.dtype = dtype
         self.semantic = semantic
+        self.default = default
 
 class StructBase:
     def __init__(self, expression : str = None):
@@ -49,16 +53,30 @@ class StructBase:
         return True
 
 class Struct(BaseType, StructBase):
-    def __init__(self, expression : str = None, **kwargs):
-        if kwargs:
+    @classmethod
+    def _has_all_defaults(cls):
+        return all(
+            m.default is not _NO_DEFAULT
+            for m in cls._member_defs.values()
+        )
+
+    def __init__(self, expression=_NO_EXPRESSION, **kwargs):
+        use_ctor = kwargs or (
+            expression is _NO_EXPRESSION and self.__class__._has_all_defaults()
+        )
+
+        if use_ctor:
             type_name = self.__class__._get_target_type_name()
             member_refs = []
             for member_name, member_def in self.__class__._member_defs.items():
-                if member_name not in kwargs:
+                if member_name in kwargs:
+                    value = kwargs[member_name]
+                elif member_def.default is not _NO_DEFAULT:
+                    value = member_def.default
+                else:
                     raise TypeError(
                         f"{type_name}(): missing member '{member_name}'"
                     )
-                value = kwargs[member_name]
                 ref = member_def.dtype._get_value_ref(value)
                 if ref is None:
                     ref = member_def.dtype(value)
@@ -75,8 +93,9 @@ class Struct(BaseType, StructBase):
             BaseType.__init__(self, ctor_expr)
             StructBase.__init__(self, None)
         else:
-            BaseType.__init__(self, expression)
-            StructBase.__init__(self, expression)
+            expr = None if expression is _NO_EXPRESSION else expression
+            BaseType.__init__(self, expr)
+            StructBase.__init__(self, expr)
 
         self._sh = self.__class__._sh
         for member_name, member in vars(self).items():
@@ -127,13 +146,14 @@ class StructDef:
         self._emit = emit
 
     def __call__(self, **kwargs):
-        define_struct(
-            self._sh,
-            self._name,
-            {
-                name : StructMemberDef(dtype_factory._get_dtype())
-                for name, dtype_factory in kwargs.items()
-            },
-            emit=self._emit
-        )
+        member_defs = {}
+        for name, spec in kwargs.items():
+            if isinstance(spec, tuple):
+                dtype_factory, default = spec
+                member_defs[name] = StructMemberDef(
+                    dtype_factory._get_dtype(), default=default
+                )
+            else:
+                member_defs[name] = StructMemberDef(spec._get_dtype())
+        define_struct(self._sh, self._name, member_defs, emit=self._emit)
 

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -80,7 +80,7 @@ void mx_metashade_standard_surface_bsdf(ClosureData closureData, float base, vec
 	}
 	// 
 	// Subsurface mix: blend SSS with diffuse
-	BSDF subsurface_mix;
+	BSDF subsurface_mix = BSDF(vec3(0), vec3(1));
 	subsurface_mix.response = mix(diffuse_bsdf.response, sss_bsdf.response, subsurface);
 	subsurface_mix.throughput = mix(diffuse_bsdf.throughput, sss_bsdf.throughput, subsurface);
 	// 

--- a/tests/ref/test_struct_constructor_init.glsl
+++ b/tests/ref/test_struct_constructor_init.glsl
@@ -13,8 +13,10 @@ struct BSDF
 
 BSDF testConstructorInit(vec3 a, vec3 b)
 {
-	// Constructor-style initialization with scalar broadcast
+	// Default construction uses member defaults
 	BSDF result = BSDF(vec3(0), vec3(1));
+	// Explicit kwargs override defaults
+	BSDF custom = BSDF(vec3(0.5), vec3(0.25));
 	// With lvalue members
 	BSDF from_args = BSDF(a, b);
 	// Overwrite a member after construction

--- a/tests/ref/test_struct_constructor_init.hlsl
+++ b/tests/ref/test_struct_constructor_init.hlsl
@@ -13,8 +13,10 @@ struct BSDF
 
 BSDF testConstructorInit(float3 a, float3 b)
 {
-	// Constructor-style initialization with scalar broadcast
+	// Default construction uses member defaults
 	BSDF result = {0.xxx, 1.xxx};
+	// Explicit kwargs override defaults
+	BSDF custom = {0.5.xxx, 0.25.xxx};
 	// With lvalue members
 	BSDF from_args = {a, b};
 	// Overwrite a member after construction

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -122,23 +122,26 @@ class TestStructDefinition:
 
     @ctx_cls_hg
     def test_struct_constructor_init(self, ctx_cls):
-        """Test one-line struct initialization via kwargs."""
+        """Test one-line struct initialization via kwargs and defaults."""
         ctx = ctx_cls(dummy_entry_point = False)
         with ctx as sh:
             self._generate_test_uniforms(sh)
 
             sh.struct('BSDF')(
-                response = sh.Float3,
-                throughput = sh.Float3
+                response = (sh.Float3, 0),
+                throughput = (sh.Float3, 1)
             )
 
             with sh.function('testConstructorInit', sh.BSDF)(
                 a = sh.Float3, b = sh.Float3
             ):
-                sh // 'Constructor-style initialization with scalar broadcast'
-                sh.result = sh.BSDF(
-                    response = sh.Float3(0),
-                    throughput = sh.Float3(1)
+                sh // 'Default construction uses member defaults'
+                sh.result = sh.BSDF()
+
+                sh // 'Explicit kwargs override defaults'
+                sh.custom = sh.BSDF(
+                    response = sh.Float3(0.5),
+                    throughput = sh.Float3(0.25)
                 )
 
                 sh // 'With lvalue members'


### PR DESCRIPTION
## Summary

- Add dataclass-style default values to `StructMemberDef`, specified as `(factory, default)` tuples in struct definitions
- `sh.BSDF()` with no args now uses member defaults to emit initialized code, e.g. `BSDF(vec3(0), vec3(1))` in GLSL
- Explicit kwargs override defaults; passing `None` as expression bypasses defaults (used internally for function parameter declarations)
- Apply to Standard Surface BSDF: all 7 explicit zero-init sites become plain `sh.BSDF()`

Closes #238

## Test plan

- [x] `test_struct_constructor_init` updated to exercise default construction, explicit override, and lvalue init
- [x] GLSL and HLSL references compiled successfully
- [x] Full test suite passes (221 tests)
- [x] Standard Surface BSDF reference regenerated