### PR TITLE
mtlx: Standard Surface: encapsulate codegen in the `Permutation` class

### DIFF
--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -43,10 +43,9 @@ from metashade.mtlx.dtypes import (
 _FUNC_NAME_BASE = "mx_metashade_standard_surface"
 _FUNC_NAME_TYPE = "_bsdf"
 FUNC_NAME = _FUNC_NAME_BASE + _FUNC_NAME_TYPE
-SUBDIR = "standard_surface"
-PRUNED_SUBDIR = "standard_surface_pruned"
 
 _SURFACESHADER_NODEDEF = "ND_standard_surface_surfaceshader"
+_NODEGRAPH_NAME = "NG_metashade_standard_surface"
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +111,437 @@ class Permutation:
         if not disabled:
             return ""
         return "_" + "_".join(f"{d}0" for d in disabled)
+
+    @property
+    def func_name(self) -> str:
+        """Full function name for the generated BSDF node."""
+        return _FUNC_NAME_BASE + self.variant_suffix + _FUNC_NAME_TYPE
+
+    @property
+    def bsdf_category(self) -> str:
+        """MaterialX node category (func_name without the ``mx_`` prefix)."""
+        return self.func_name.removeprefix("mx_")
+
+    @property
+    def nodegraph_name(self) -> str:
+        """Nodegraph name for the surfaceshader wiring."""
+        return _NODEGRAPH_NAME + self.variant_suffix
+
+    @property
+    def surfaceshader_filename(self) -> str:
+        """Output ``.mtlx`` filename for the surfaceshader nodegraph."""
+        return f"{_FUNC_NAME_BASE}{self.variant_suffix}_surfaceshader.mtlx"
+
+    def generate_bsdf(
+        self,
+        ctx: GlslGeneratorContext,
+        stdlib_doc: mx.Document,
+    ):
+        """Generate the Standard Surface BSDF source-code node.
+
+        Args:
+            ctx: A production generator context (or any subclass such as
+                 ``GlslTestContext``).  Only the ``_sh`` generator and
+                 ``add_node_impl`` method are used.
+            stdlib_doc: A MaterialX document with the standard library loaded.
+        """
+        sh = ctx._sh
+
+        register_mtlx_closure_structs(sh)
+        _acquire_stdlib_sourcecode_nodes(sh, stdlib_doc, _STDLIB_IMPORTS)
+        sh.instantiate(_mx_metashade_rotate_vector3)
+
+        surfaceshader_nodedef = stdlib_doc.getNodeDef(_SURFACESHADER_NODEDEF)
+        assert surfaceshader_nodedef is not None, (
+            f"Could not find {_SURFACESHADER_NODEDEF}"
+        )
+        params = _build_bsdf_params(sh, surfaceshader_nodedef)
+
+        with sh.function(self.func_name)(**params):
+            sh // ""
+            sh // "Coat affect roughness: blend specular roughness toward 1.0"
+            sh.coat_roughness_factor = (
+                sh.coat_affect_roughness * sh.coat * sh.coat_roughness
+            )
+            sh.coat_affected_specular_roughness = (
+                sh.specular_roughness
+                * (sh.Float(1) - sh.coat_roughness_factor)
+                + sh.coat_roughness_factor
+            )
+
+            sh // ""
+            sh // "Roughness"
+            sh.main_roughness = sh.Float2()
+            sh.mx_roughness_anisotropy(
+                roughness=sh.coat_affected_specular_roughness,
+                anisotropy=sh.specular_anisotropy,
+                out_=sh.main_roughness,
+            )
+
+            sh // ""
+            sh // "Tangent rotation"
+            sh.main_tangent = sh.tangent
+            with sh.if_(sh.specular_anisotropy > 0.0):
+                sh.tangent_rotate_degree = sh.specular_rotation * 360.0
+                sh.tangent_rotated = sh.Float3()
+                sh._mx_metashade_rotate_vector3(
+                    in_=sh.tangent,
+                    amount=sh.tangent_rotate_degree,
+                    axis=sh.normal,
+                    result=sh.tangent_rotated,
+                )
+                sh.main_tangent = sh.tangent_rotated.normalize()
+
+            sh // ""
+            sh // "Coat tangent rotation"
+            sh.coat_tangent = sh.tangent
+            with sh.if_(sh.coat_anisotropy > 0.0):
+                sh.coat_tangent_rotate_degree = sh.coat_rotation * 360.0
+                sh.coat_tangent_rotated = sh.Float3()
+                sh._mx_metashade_rotate_vector3(
+                    in_=sh.tangent,
+                    amount=sh.coat_tangent_rotate_degree,
+                    axis=sh.coat_normal,
+                    result=sh.coat_tangent_rotated,
+                )
+                sh.coat_tangent = sh.coat_tangent_rotated.normalize()
+
+            sh // ""
+            sh // "Coat affect color: darken diffuse under the coat"
+            sh.coat_gamma = sh.RgbF(
+                sh.coat.clamp(0.0, 1.0) * sh.coat_affect_color + 1.0
+            )
+            sh.coat_affected_diffuse_color = (
+                sh.base_color.clamp(0.0, 1.0).pow(sh.coat_gamma)
+            )
+
+            if self.subsurface:
+                sh // ""
+                sh // "Coat affect subsurface color"
+                sh.coat_affected_subsurface_color = (
+                    sh.subsurface_color.clamp(0.0, 1.0).pow(sh.coat_gamma)
+                )
+
+            sh // ""
+            sh // "Diffuse BSDF (Oren-Nayar)"
+            sh // ("`energy_compensation=false` to match the Standard "
+                   "Surface spec, ")
+            sh // "instead of the more physically-correct `true` in OpenPBR"
+            sh.diffuse_bsdf = sh.BSDF(
+                response=sh.Float3(0), throughput=sh.Float3(1)
+            )
+            sh.mx_oren_nayar_diffuse_bsdf(
+                closureData=sh.closureData,
+                weight=sh.base,
+                color=sh.coat_affected_diffuse_color,
+                roughness=sh.diffuse_roughness,
+                normal=sh.normal,
+                energy_compensation=False,
+                bsdf=sh.diffuse_bsdf,
+            )
+
+            if self.subsurface:
+                sh // ""
+                sh // "Subsurface scattering"
+                sh.subsurface_radius_scaled = (
+                    sh.subsurface_radius * sh.subsurface_scale
+                )
+                sh.sss_bsdf = sh.BSDF(
+                    response=sh.Float3(0), throughput=sh.Float3(1)
+                )
+                with sh.if_(sh.thin_walled):
+                    sh.mx_translucent_bsdf(
+                        closureData=sh.closureData,
+                        weight=1.0,
+                        color=sh.coat_affected_subsurface_color,
+                        normal=sh.normal,
+                        bsdf=sh.sss_bsdf,
+                    )
+                with sh.else_():
+                    sh.mx_subsurface_bsdf(
+                        closureData=sh.closureData,
+                        weight=1.0,
+                        color=sh.coat_affected_subsurface_color,
+                        radius=sh.subsurface_radius_scaled,
+                        anisotropy=sh.subsurface_anisotropy,
+                        normal=sh.normal,
+                        bsdf=sh.sss_bsdf,
+                    )
+
+                sh // ""
+                sh // "Subsurface mix: blend SSS with diffuse"
+                sh.subsurface_mix = sh.BSDF()
+                sh.subsurface_mix.response = sh.subsurface.lerp(
+                    sh.diffuse_bsdf.response, sh.sss_bsdf.response
+                )
+                sh.subsurface_mix.throughput = sh.subsurface.lerp(
+                    sh.diffuse_bsdf.throughput, sh.sss_bsdf.throughput
+                )
+            else:
+                sh.subsurface_mix = sh.diffuse_bsdf
+
+            sh // ""
+            sh // "Sheen BSDF"
+            sh.sheen_bsdf_out = sh.BSDF(
+                response=sh.Float3(0), throughput=sh.Float3(1)
+            )
+            sh.mx_sheen_bsdf(
+                closureData=sh.closureData,
+                weight=sh.sheen,
+                color=sh.sheen_color,
+                roughness=sh.sheen_roughness,
+                normal=sh.normal,
+                mode=0,
+                bsdf=sh.sheen_bsdf_out,
+            )
+
+            sh // ""
+            sh // "Sheen layer: sheen over subsurface mix"
+            sh.bsdf.response = (
+                sh.sheen_bsdf_out.response
+                + sh.subsurface_mix.response * sh.sheen_bsdf_out.throughput
+            )
+            sh.bsdf.throughput = (
+                sh.sheen_bsdf_out.throughput * sh.subsurface_mix.throughput
+            )
+
+            sh // ""
+            sh // "Transmission roughness (coat-affected)"
+            sh.transmission_roughness_clamped = (
+                (sh.specular_roughness + sh.transmission_extra_roughness)
+                .clamp(0.0, 1.0)
+            )
+            sh.transmission_roughness_scalar = (
+                sh.transmission_roughness_clamped
+                * (sh.Float(1) - sh.coat_roughness_factor)
+                + sh.coat_roughness_factor
+            )
+            sh.transmission_roughness = sh.Float2()
+            sh.mx_roughness_anisotropy(
+                roughness=sh.transmission_roughness_scalar,
+                anisotropy=sh.specular_anisotropy,
+                out_=sh.transmission_roughness,
+            )
+
+            sh // ""
+            sh // "Transmission BSDF (dielectric transmission)"
+            sh.transmission_bsdf = sh.BSDF(
+                response=sh.Float3(0), throughput=sh.Float3(1)
+            )
+            sh.mx_dielectric_bsdf(
+                closureData=sh.closureData,
+                weight=1.0,
+                tint=sh.transmission_color,
+                ior=sh.specular_IOR,
+                roughness=sh.transmission_roughness,
+                retroreflective=False,
+                thinfilm_thickness=0.0,
+                thinfilm_ior=1.5,
+                normal=sh.normal,
+                tangent=sh.main_tangent,
+                distribution=_DISTRIBUTION_GGX,
+                scatter_mode=_SCATTER_T,
+                bsdf=sh.transmission_bsdf,
+            )
+
+            sh // ""
+            sh // "Transmission mix: blend transmission with sheen layer"
+            sh.bsdf.response = sh.transmission.lerp(
+                sh.bsdf.response, sh.transmission_bsdf.response
+            )
+            sh.bsdf.throughput = sh.transmission.lerp(
+                sh.bsdf.throughput, sh.transmission_bsdf.throughput
+            )
+
+            sh // ""
+            sh // "Specular BSDF (dielectric reflection)"
+            sh.specular_bsdf = sh.BSDF(
+                response=sh.Float3(0), throughput=sh.Float3(1)
+            )
+            sh.mx_dielectric_bsdf(
+                closureData=sh.closureData,
+                weight=sh.specular,
+                tint=sh.specular_color,
+                ior=sh.specular_IOR,
+                roughness=sh.main_roughness,
+                retroreflective=False,
+                thinfilm_thickness=sh.thin_film_thickness,
+                thinfilm_ior=sh.thin_film_IOR,
+                normal=sh.normal,
+                tangent=sh.main_tangent,
+                distribution=_DISTRIBUTION_GGX,
+                scatter_mode=_SCATTER_R,
+                bsdf=sh.specular_bsdf,
+            )
+
+            sh // ""
+            sh // "Layer: specular over transmission mix"
+            sh.bsdf.response = (
+                sh.specular_bsdf.response
+                + sh.bsdf.response * sh.specular_bsdf.throughput
+            )
+            sh.bsdf.throughput = (
+                sh.specular_bsdf.throughput * sh.bsdf.throughput
+            )
+
+            sh // ""
+            sh // ("Artistic IOR (reflectivity/edge-color -> physical "
+                   "IOR/extinction)")
+            sh.metal_reflectivity = sh.base_color * sh.base
+            sh.metal_edgecolor = sh.specular_color * sh.specular
+            sh.ior_n = sh.RgbF()
+            sh.ior_k = sh.RgbF()
+            sh.mx_artistic_ior(
+                reflectivity=sh.metal_reflectivity,
+                edge_color=sh.metal_edgecolor,
+                ior=sh.ior_n,
+                extinction=sh.ior_k,
+            )
+
+            sh // ""
+            sh // "Conductor BSDF (metal reflection)"
+            sh.metal_bsdf = sh.BSDF(
+                response=sh.Float3(0), throughput=sh.Float3(1)
+            )
+            sh.mx_conductor_bsdf(
+                closureData=sh.closureData,
+                weight=sh.metalness,
+                ior=sh.ior_n,
+                extinction=sh.ior_k,
+                roughness=sh.main_roughness,
+                retroreflective=False,
+                thinfilm_thickness=sh.thin_film_thickness,
+                thinfilm_ior=sh.thin_film_IOR,
+                normal=sh.normal,
+                tangent=sh.main_tangent,
+                distribution=_DISTRIBUTION_GGX,
+                bsdf=sh.metal_bsdf,
+            )
+
+            sh // ""
+            sh // "Metalness mix: conductor (fg) vs specular layer (bg)"
+            sh // ("Conductor response is already scaled by metalness "
+                   "(the weight),")
+            sh // "so we just add it to the attenuated specular layer."
+            sh.one_minus_metalness = sh.Float(1) - sh.metalness
+            sh.bsdf.response = (
+                sh.metal_bsdf.response
+                + sh.bsdf.response * sh.one_minus_metalness
+            )
+            sh.bsdf.throughput = (
+                sh.metal_bsdf.throughput
+                + sh.bsdf.throughput * sh.one_minus_metalness
+            )
+
+            sh // ""
+            sh // "Coat attenuation: tint underlying layers by coat color"
+            sh // ("Float3 coercion needed: RgbF lerp result -> "
+                   "Float3 for BSDF multiply")
+            sh.coat_attenuation = sh.Float3(
+                sh.coat.lerp(sh.RgbF(1.0), sh.coat_color)
+            )
+            sh.bsdf.response = sh.bsdf.response * sh.coat_attenuation
+            sh.bsdf.throughput = sh.bsdf.throughput * sh.coat_attenuation
+
+            sh // ""
+            sh // "Coat roughness"
+            sh.coat_roughness_vec = sh.Float2()
+            sh.mx_roughness_anisotropy(
+                roughness=sh.coat_roughness,
+                anisotropy=sh.coat_anisotropy,
+                out_=sh.coat_roughness_vec,
+            )
+
+            sh // ""
+            sh // "Coat BSDF (dielectric reflection)"
+            sh.coat_bsdf = sh.BSDF(
+                response=sh.Float3(0), throughput=sh.Float3(1)
+            )
+            sh.mx_dielectric_bsdf(
+                closureData=sh.closureData,
+                weight=sh.coat,
+                tint=[1.0, 1.0, 1.0],
+                ior=sh.coat_IOR,
+                roughness=sh.coat_roughness_vec,
+                retroreflective=False,
+                thinfilm_thickness=0.0,
+                thinfilm_ior=1.5,
+                normal=sh.coat_normal,
+                tangent=sh.coat_tangent,
+                distribution=_DISTRIBUTION_GGX,
+                scatter_mode=_SCATTER_R,
+                bsdf=sh.coat_bsdf,
+            )
+
+            sh // ""
+            sh // "Coat layer: coat over attenuated base"
+            sh.bsdf.response = (
+                sh.coat_bsdf.response
+                + sh.bsdf.response * sh.coat_bsdf.throughput
+            )
+            sh.bsdf.throughput = (
+                sh.coat_bsdf.throughput * sh.bsdf.throughput
+            )
+
+        ctx.add_node_impl(
+            func_name=self.func_name,
+            mx_doc_string="Metashade Standard Surface BSDF",
+        )
+
+    def generate_surfaceshader_nodegraph(
+        self,
+        stock_nodedef: mx.NodeDef,
+    ) -> mx.Document:
+        """Build the surfaceshader nodegraph that wires the BSDF to a surface.
+
+        Produces a nodegraph wiring the BSDF source-code node, emission,
+        opacity, and the ``surface`` constructor.
+
+        Returns a :class:`mx.Document` ready to be written with
+        :func:`mx.writeToXmlFile`.
+        """
+        doc = mx.createDocument()
+
+        ng = doc.addNodeGraph(self.nodegraph_name)
+        ng.setNodeDefString(_SURFACESHADER_NODEDEF)
+
+        bsdf_node = ng.addNode(self.bsdf_category, "std_surface", "BSDF")
+        for inp in stock_nodedef.getActiveInputs():
+            name = inp.getName()
+            if name not in _BSDF_INPUTS:
+                continue
+            bsdf_node.addInput(name, inp.getType()).setInterfaceName(name)
+
+        emission_weight = ng.addNode("multiply", "emission_weight", "color3")
+        emission_weight.addInput("in1", "color3").setInterfaceName(
+            "emission_color"
+        )
+        emission_weight.addInput("in2", "float").setInterfaceName("emission")
+
+        emission_edf = ng.addNode("uniform_edf", "emission_edf", "EDF")
+        emission_edf.addInput("color", "color3").setNodeName("emission_weight")
+
+        opacity_lum = ng.addNode("luminance", "opacity_luminance", "color3")
+        opacity_lum.addInput("in", "color3").setInterfaceName("opacity")
+
+        opacity_float = ng.addNode(
+            "extract", "opacity_luminance_float", "float"
+        )
+        opacity_float.addInput("in", "color3").setNodeName(
+            "opacity_luminance"
+        )
+        opacity_float.addInput("index", "integer").setValueString("0")
+
+        surface = ng.addNode("surface", "surface_ctor", "surfaceshader")
+        surface.addInput("bsdf", "BSDF").setNodeName("std_surface")
+        surface.addInput("edf", "EDF").setNodeName("emission_edf")
+        surface.addInput("opacity", "float").setNodeName(
+            "opacity_luminance_float"
+        )
+
+        ng.addOutput("out", "surfaceshader").setNodeName("surface_ctor")
+
+        return doc
 
 Permutation.ALL = Permutation()
 
@@ -227,427 +657,3 @@ def _mx_metashade_rotate_vector3(
         + in_.cross(sh.axis_n) * sh.s
         + sh.axis_n * sh.axis_n.dot(in_) * (sh.Float(1) - sh.c)
     )
-
-
-def generate(
-    ctx: GlslGeneratorContext,
-    stdlib_doc: mx.Document,
-    perm: Permutation = Permutation.ALL,
-):
-    """Generate the Standard Surface BSDF source-code node.
-
-    Args:
-        ctx: A production generator context (or any subclass such as
-             ``GlslTestContext``).  Only the ``_sh`` generator and
-             ``add_node_impl`` method are used.
-        stdlib_doc: A MaterialX document with the standard library loaded.
-        perm: Which lobes to emit.  ``Permutation.ALL`` (default) generates
-              the full BSDF.  Disabled lobes are pruned at code-generation
-              time (design-time ``if``, not runtime).
-    """
-    func_name = _FUNC_NAME_BASE + perm.variant_suffix + _FUNC_NAME_TYPE
-
-    sh = ctx._sh
-
-    register_mtlx_closure_structs(sh)
-    _acquire_stdlib_sourcecode_nodes(sh, stdlib_doc, _STDLIB_IMPORTS)
-    sh.instantiate(_mx_metashade_rotate_vector3)
-
-    surfaceshader_nodedef = stdlib_doc.getNodeDef(_SURFACESHADER_NODEDEF)
-    assert surfaceshader_nodedef is not None, (
-        f"Could not find {_SURFACESHADER_NODEDEF}"
-    )
-    params = _build_bsdf_params(sh, surfaceshader_nodedef)
-
-    with sh.function(func_name)(**params):
-        sh // ""
-        sh // "Coat affect roughness: blend specular roughness toward 1.0"
-        sh.coat_roughness_factor = (
-            sh.coat_affect_roughness * sh.coat * sh.coat_roughness
-        )
-        sh.coat_affected_specular_roughness = (
-            sh.specular_roughness * (sh.Float(1) - sh.coat_roughness_factor)
-            + sh.coat_roughness_factor
-        )
-
-        sh // ""
-        sh // "Roughness"
-        sh.main_roughness = sh.Float2()
-        sh.mx_roughness_anisotropy(
-            roughness=sh.coat_affected_specular_roughness,
-            anisotropy=sh.specular_anisotropy,
-            out_=sh.main_roughness,
-        )
-
-        sh // ""
-        sh // "Tangent rotation"
-        sh.main_tangent = sh.tangent
-        with sh.if_(sh.specular_anisotropy > 0.0):
-            sh.tangent_rotate_degree = sh.specular_rotation * 360.0
-            sh.tangent_rotated = sh.Float3()
-            sh._mx_metashade_rotate_vector3(
-                in_=sh.tangent,
-                amount=sh.tangent_rotate_degree,
-                axis=sh.normal,
-                result=sh.tangent_rotated,
-            )
-            sh.main_tangent = sh.tangent_rotated.normalize()
-
-        sh // ""
-        sh // "Coat tangent rotation"
-        sh.coat_tangent = sh.tangent
-        with sh.if_(sh.coat_anisotropy > 0.0):
-            sh.coat_tangent_rotate_degree = sh.coat_rotation * 360.0
-            sh.coat_tangent_rotated = sh.Float3()
-            sh._mx_metashade_rotate_vector3(
-                in_=sh.tangent,
-                amount=sh.coat_tangent_rotate_degree,
-                axis=sh.coat_normal,
-                result=sh.coat_tangent_rotated,
-            )
-            sh.coat_tangent = sh.coat_tangent_rotated.normalize()
-
-        sh // ""
-        sh // "Coat affect color: darken diffuse under the coat"
-        # RgbF workaround: exponent is unitless, not a color (#224)
-        sh.coat_gamma = sh.RgbF(
-            sh.coat.clamp(0.0, 1.0) * sh.coat_affect_color + 1.0
-        )
-        sh.coat_affected_diffuse_color = (
-            sh.base_color.clamp(0.0, 1.0).pow(sh.coat_gamma)
-        )
-
-        if perm.subsurface:
-            sh // ""
-            sh // "Coat affect subsurface color"
-            # RgbF workaround: exponent is unitless, not a color (#224)
-            sh.coat_affected_subsurface_color = (
-                sh.subsurface_color.clamp(0.0, 1.0).pow(sh.coat_gamma)
-            )
-
-        sh // ""
-        sh // "Diffuse BSDF (Oren-Nayar)"
-        sh // "`energy_compensation=false` to match the Standard Surface spec, "
-        sh // "instead of the more physically-correct `true` in OpenPBR"
-        sh.diffuse_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
-        sh.mx_oren_nayar_diffuse_bsdf(
-            closureData=sh.closureData,
-            weight=sh.base,
-            color=sh.coat_affected_diffuse_color,
-            roughness=sh.diffuse_roughness,
-            normal=sh.normal,
-            energy_compensation=False,
-            bsdf=sh.diffuse_bsdf,
-        )
-
-        if perm.subsurface:
-            sh // ""
-            sh // "Subsurface scattering"
-            sh.subsurface_radius_scaled = sh.subsurface_radius * sh.subsurface_scale
-            sh.sss_bsdf = sh.BSDF(
-                response = sh.Float3(0), throughput = sh.Float3(1)
-            )
-            with sh.if_(sh.thin_walled):
-                sh.mx_translucent_bsdf(
-                    closureData=sh.closureData,
-                    weight=1.0,
-                    color=sh.coat_affected_subsurface_color,
-                    normal=sh.normal,
-                    bsdf=sh.sss_bsdf,
-                )
-            with sh.else_():
-                sh.mx_subsurface_bsdf(
-                    closureData=sh.closureData,
-                    weight=1.0,
-                    color=sh.coat_affected_subsurface_color,
-                    radius=sh.subsurface_radius_scaled,
-                    anisotropy=sh.subsurface_anisotropy,
-                    normal=sh.normal,
-                    bsdf=sh.sss_bsdf,
-                )
-
-            sh // ""
-            sh // "Subsurface mix: blend SSS with diffuse"
-            sh.subsurface_mix = sh.BSDF()
-            sh.subsurface_mix.response = sh.subsurface.lerp(
-                sh.diffuse_bsdf.response, sh.sss_bsdf.response
-            )
-            sh.subsurface_mix.throughput = sh.subsurface.lerp(
-                sh.diffuse_bsdf.throughput, sh.sss_bsdf.throughput
-            )
-        else:
-            sh.subsurface_mix = sh.diffuse_bsdf
-
-        sh // ""
-        sh // "Sheen BSDF"
-        sh.sheen_bsdf_out = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
-        sh.mx_sheen_bsdf(
-            closureData=sh.closureData,
-            weight=sh.sheen,
-            color=sh.sheen_color,
-            roughness=sh.sheen_roughness,
-            normal=sh.normal,
-            mode=0,
-            bsdf=sh.sheen_bsdf_out,
-        )
-
-        sh // ""
-        sh // "Sheen layer: sheen over subsurface mix"
-        sh.bsdf.response = (
-            sh.sheen_bsdf_out.response
-            + sh.subsurface_mix.response * sh.sheen_bsdf_out.throughput
-        )
-        sh.bsdf.throughput = (
-            sh.sheen_bsdf_out.throughput * sh.subsurface_mix.throughput
-        )
-
-        sh // ""
-        sh // "Transmission roughness (coat-affected)"
-        sh.transmission_roughness_clamped = (
-            (sh.specular_roughness + sh.transmission_extra_roughness)
-            .clamp(0.0, 1.0)
-        )
-        sh.transmission_roughness_scalar = (
-            sh.transmission_roughness_clamped
-            * (sh.Float(1) - sh.coat_roughness_factor)
-            + sh.coat_roughness_factor
-        )
-        sh.transmission_roughness = sh.Float2()
-        sh.mx_roughness_anisotropy(
-            roughness=sh.transmission_roughness_scalar,
-            anisotropy=sh.specular_anisotropy,
-            out_=sh.transmission_roughness,
-        )
-
-        sh // ""
-        sh // "Transmission BSDF (dielectric transmission)"
-        sh.transmission_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
-        sh.mx_dielectric_bsdf(
-            closureData=sh.closureData,
-            weight=1.0,
-            tint=sh.transmission_color,
-            ior=sh.specular_IOR,
-            roughness=sh.transmission_roughness,
-            retroreflective=False,
-            thinfilm_thickness=0.0,
-            thinfilm_ior=1.5,
-            normal=sh.normal,
-            tangent=sh.main_tangent,
-            distribution=_DISTRIBUTION_GGX,
-            scatter_mode=_SCATTER_T,
-            bsdf=sh.transmission_bsdf,
-        )
-
-        sh // ""
-        sh // "Transmission mix: blend transmission with sheen layer"
-        sh.bsdf.response = sh.transmission.lerp(
-            sh.bsdf.response, sh.transmission_bsdf.response
-        )
-        sh.bsdf.throughput = sh.transmission.lerp(
-            sh.bsdf.throughput, sh.transmission_bsdf.throughput
-        )
-
-        sh // ""
-        sh // "Specular BSDF (dielectric reflection)"
-        sh.specular_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
-        sh.mx_dielectric_bsdf(
-            closureData=sh.closureData,
-            weight=sh.specular,
-            tint=sh.specular_color,
-            ior=sh.specular_IOR,
-            roughness=sh.main_roughness,
-            retroreflective=False,
-            thinfilm_thickness=sh.thin_film_thickness,
-            thinfilm_ior=sh.thin_film_IOR,
-            normal=sh.normal,
-            tangent=sh.main_tangent,
-            distribution=_DISTRIBUTION_GGX,
-            scatter_mode=_SCATTER_R,
-            bsdf=sh.specular_bsdf,
-        )
-
-        sh // ""
-        sh // "Layer: specular over transmission mix"
-        sh.bsdf.response = (
-            sh.specular_bsdf.response
-            + sh.bsdf.response * sh.specular_bsdf.throughput
-        )
-        sh.bsdf.throughput = (
-            sh.specular_bsdf.throughput * sh.bsdf.throughput
-        )
-
-        sh // ""
-        sh // "Artistic IOR (reflectivity/edge-color -> physical IOR/extinction)"
-        sh.metal_reflectivity = sh.base_color * sh.base
-        sh.metal_edgecolor = sh.specular_color * sh.specular
-        sh.ior_n = sh.RgbF()
-        sh.ior_k = sh.RgbF()
-        sh.mx_artistic_ior(
-            reflectivity=sh.metal_reflectivity,
-            edge_color=sh.metal_edgecolor,
-            ior=sh.ior_n,
-            extinction=sh.ior_k,
-        )
-
-        sh // ""
-        sh // "Conductor BSDF (metal reflection)"
-        sh.metal_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
-        sh.mx_conductor_bsdf(
-            closureData=sh.closureData,
-            weight=sh.metalness,
-            ior=sh.ior_n,
-            extinction=sh.ior_k,
-            roughness=sh.main_roughness,
-            retroreflective=False,
-            thinfilm_thickness=sh.thin_film_thickness,
-            thinfilm_ior=sh.thin_film_IOR,
-            normal=sh.normal,
-            tangent=sh.main_tangent,
-            distribution=_DISTRIBUTION_GGX,
-            bsdf=sh.metal_bsdf,
-        )
-
-        sh // ""
-        sh // "Metalness mix: conductor (fg) vs specular layer (bg)"
-        sh // "Conductor response is already scaled by metalness (the weight),"
-        sh // "so we just add it to the attenuated specular layer."
-        sh.one_minus_metalness = sh.Float(1) - sh.metalness
-        sh.bsdf.response = (
-            sh.metal_bsdf.response
-            + sh.bsdf.response * sh.one_minus_metalness
-        )
-        sh.bsdf.throughput = (
-            sh.metal_bsdf.throughput
-            + sh.bsdf.throughput * sh.one_minus_metalness
-        )
-
-        sh // ""
-        sh // "Coat attenuation: tint underlying layers by coat color"
-        sh // "Float3 coercion needed: RgbF lerp result -> Float3 for BSDF multiply"
-        sh.coat_attenuation = sh.Float3(
-            sh.coat.lerp(sh.RgbF(1.0), sh.coat_color)
-        )
-        sh.bsdf.response = sh.bsdf.response * sh.coat_attenuation
-        sh.bsdf.throughput = sh.bsdf.throughput * sh.coat_attenuation
-
-        sh // ""
-        sh // "Coat roughness"
-        sh.coat_roughness_vec = sh.Float2()
-        sh.mx_roughness_anisotropy(
-            roughness=sh.coat_roughness,
-            anisotropy=sh.coat_anisotropy,
-            out_=sh.coat_roughness_vec,
-        )
-
-        sh // ""
-        sh // "Coat BSDF (dielectric reflection)"
-        sh.coat_bsdf = sh.BSDF(
-            response = sh.Float3(0), throughput = sh.Float3(1)
-        )
-        sh.mx_dielectric_bsdf(
-            closureData=sh.closureData,
-            weight=sh.coat,
-            tint=[1.0, 1.0, 1.0],
-            ior=sh.coat_IOR,
-            roughness=sh.coat_roughness_vec,
-            retroreflective=False,
-            thinfilm_thickness=0.0,
-            thinfilm_ior=1.5,
-            normal=sh.coat_normal,
-            tangent=sh.coat_tangent,
-            distribution=_DISTRIBUTION_GGX,
-            scatter_mode=_SCATTER_R,
-            bsdf=sh.coat_bsdf,
-        )
-
-        sh // ""
-        sh // "Coat layer: coat over attenuated base"
-        sh.bsdf.response = (
-            sh.coat_bsdf.response
-            + sh.bsdf.response * sh.coat_bsdf.throughput
-        )
-        sh.bsdf.throughput = (
-            sh.coat_bsdf.throughput * sh.bsdf.throughput
-        )
-
-    ctx.add_node_impl(
-        func_name=func_name,
-        mx_doc_string="Metashade Standard Surface BSDF",
-    )
-
-
-# ---------------------------------------------------------------------------
-# Surfaceshader nodegraph generation
-# ---------------------------------------------------------------------------
-
-_NODEGRAPH_NAME = "NG_metashade_standard_surface"
-_BSDF_NODE_CATEGORY = FUNC_NAME.removeprefix("mx_")
-
-
-def generate_surfaceshader_nodegraph(
-    stock_nodedef: mx.NodeDef,
-    bsdf_category: str = _BSDF_NODE_CATEGORY,
-    nodegraph_name: str = _NODEGRAPH_NAME,
-    target_nodedef_name: str = _SURFACESHADER_NODEDEF,
-) -> mx.Document:
-    """Build the surfaceshader nodegraph that wires the BSDF to a surface.
-
-    Produces a nodegraph wiring the BSDF source-code node, emission,
-    opacity, and the ``surface`` constructor.
-
-    The *bsdf_category* / *nodegraph_name* / *target_nodedef_name*
-    parameters are overridable so that variant permutations can reuse
-    the same builder with different names.
-
-    Returns a :class:`mx.Document` ready to be written with
-    :func:`mx.writeToXmlFile`.
-    """
-    doc = mx.createDocument()
-
-    ng = doc.addNodeGraph(nodegraph_name)
-    ng.setNodeDefString(target_nodedef_name)
-
-    # --- BSDF node ---
-    bsdf_node = ng.addNode(bsdf_category, "std_surface", "BSDF")
-    for inp in stock_nodedef.getActiveInputs():
-        name = inp.getName()
-        if name not in _BSDF_INPUTS:
-            continue
-        bsdf_node.addInput(name, inp.getType()).setInterfaceName(name)
-
-    # --- Emission chain ---
-    emission_weight = ng.addNode("multiply", "emission_weight", "color3")
-    emission_weight.addInput("in1", "color3").setInterfaceName("emission_color")
-    emission_weight.addInput("in2", "float").setInterfaceName("emission")
-
-    emission_edf = ng.addNode("uniform_edf", "emission_edf", "EDF")
-    emission_edf.addInput("color", "color3").setNodeName("emission_weight")
-
-    # --- Opacity chain ---
-    opacity_lum = ng.addNode("luminance", "opacity_luminance", "color3")
-    opacity_lum.addInput("in", "color3").setInterfaceName("opacity")
-
-    opacity_float = ng.addNode("extract", "opacity_luminance_float", "float")
-    opacity_float.addInput("in", "color3").setNodeName("opacity_luminance")
-    opacity_float.addInput("index", "integer").setValueString("0")
-
-    # --- Surface constructor ---
-    surface = ng.addNode("surface", "surface_ctor", "surfaceshader")
-    surface.addInput("bsdf", "BSDF").setNodeName("std_surface")
-    surface.addInput("edf", "EDF").setNodeName("emission_edf")
-    surface.addInput("opacity", "float").setNodeName("opacity_luminance_float")
-
-    # --- Output ---
-    ng.addOutput("out", "surfaceshader").setNodeName("surface_ctor")
-
-    return doc

--- a/tests/mtlx/test_mtlx_standard_surface.py
+++ b/tests/mtlx/test_mtlx_standard_surface.py
@@ -102,42 +102,31 @@ class TestStandardSurface:
     through the context and RefDiffer'd in CI.
     """
 
-    @pytest.mark.parametrize("perm", [
+    @pytest.mark.parametrize("permutation", [
         pytest.param(standard_surface.Permutation(), id="full"),
         pytest.param(
             standard_surface.Permutation(subsurface=False), id="subsurface0",
         ),
     ])
-    def test_generate(self, stdlib_doc, perm):
+    def test_generate(self, stdlib_doc, permutation):
         """Generate the Standard Surface BSDF + surfaceshader."""
-        base_name = (standard_surface._FUNC_NAME_BASE
-                     + perm.variant_suffix
-                     + standard_surface._FUNC_NAME_TYPE)
-        subdir = (standard_surface.SUBDIR if perm == standard_surface.Permutation.ALL
-                  else standard_surface.PRUNED_SUBDIR)
+        subdir = ("standard_surface"
+                  if permutation == standard_surface.Permutation.ALL
+                  else "standard_surface_pruned")
 
         with GlslTestContext(
-            base_name=base_name,
+            base_name=permutation.func_name,
             impl_only=False,
             subdir=subdir,
         ) as glsl_ctx:
-            standard_surface.generate(glsl_ctx, stdlib_doc, perm=perm)
+            permutation.generate_bsdf(glsl_ctx, stdlib_doc)
 
-        bsdf_category = base_name.removeprefix("mx_")
         stock_nodedef = stdlib_doc.getNodeDef(
             standard_surface._SURFACESHADER_NODEDEF
         )
-        ng_doc = standard_surface.generate_surfaceshader_nodegraph(
-            stock_nodedef,
-            bsdf_category=bsdf_category,
-            nodegraph_name=(
-                standard_surface._NODEGRAPH_NAME + perm.variant_suffix
-            ),
-        )
+        ng_doc = permutation.generate_surfaceshader_nodegraph(stock_nodedef)
 
-        ss_filename = (
-            f"{standard_surface._FUNC_NAME_BASE}"
-            f"{perm.variant_suffix}_surfaceshader.mtlx"
-        )
-        with MtlxTestContext(ss_filename, subdir=subdir) as mtlx_ctx:
+        with MtlxTestContext(
+            permutation.surfaceshader_filename, subdir=subdir,
+        ) as mtlx_ctx:
             mtlx_ctx.write(ng_doc)


### PR DESCRIPTION
## Summary

- Move `generate_bsdf()` and `generate_surfaceshader_nodegraph()` from module-level functions into `Permutation` methods
- Add derived properties (`func_name`, `bsdf_category`, `nodegraph_name`, `surfaceshader_filename`) so callers no longer assemble variant names manually
- Remove `SUBDIR`/`PRUNED_SUBDIR` constants from the production module (test-only concern)

## Test plan

- [x] All 3 existing tests pass (`TestStandardSurfacePink`, `TestStandardSurface[full]`, `TestStandardSurface[subsurface0]`)
- [x] Zero ref diffs — generated GLSL and MTLX output is identical