### PR TITLE
mtlx: Prune stdlib imports for disabled lobes

### DIFF
--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -588,26 +588,32 @@ _BSDF_INPUTS = frozenset({
 })
 
 
-def _find_genglsl_impl(stdlib_doc, node_name):
-    """Find the genglsl source-code implementation for a node."""
-    for impl in stdlib_doc.getImplementations():
-        if (
-            impl.getNodeDefString().endswith(node_name)
-            and impl.getTarget() == "genglsl"
-        ):
-            return impl
-    return None
-
-
 def _acquire_stdlib_sourcecode_nodes(sh, stdlib_doc, node_names):
-    """Resolve, include, and acquire stdlib sourcecode nodes."""
+    """Resolve, include, and acquire stdlib sourcecode nodes.
+
+    Nodes are grouped by header file.  Both the ``#include`` directives
+    and the function acquisitions within each header are emitted in
+    sorted order for deterministic output.
+    """
+    all_impls = stdlib_doc.getImplementations()
+    by_file: dict[str, list[tuple[str, object]]] = {}
     for name in node_names:
-        impl = _find_genglsl_impl(stdlib_doc, name)
+        impl = next(
+            (i for i in all_impls
+             if i.getNodeDefString().endswith(name)
+             and i.getTarget() == "genglsl"),
+            None,
+        )
         assert impl is not None, (
             f"Could not find genglsl impl for {name}"
         )
-        sh.include(impl.getAttribute("file"))
-        acquire_function(sh, impl)
+        file_path = impl.getAttribute("file")
+        by_file.setdefault(file_path, []).append((name, impl))
+
+    for file_path in sorted(by_file):
+        sh.include(file_path)
+        for _, impl in sorted(by_file[file_path]):
+            acquire_function(sh, impl)
 
 
 def _build_bsdf_params(sh, surfaceshader_nodedef):

--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -148,7 +148,13 @@ class Permutation:
         sh = ctx._sh
 
         register_mtlx_closure_structs(sh)
-        _acquire_stdlib_sourcecode_nodes(sh, stdlib_doc, _STDLIB_IMPORTS)
+
+        stdlib_imports = _BASE_STDLIB_IMPORTS | frozenset().union(*(
+            lobe.stdlib_imports for lobe in LOBES
+            if getattr(self, lobe.name)
+        ))
+
+        _acquire_stdlib_sourcecode_nodes(sh, stdlib_doc, stdlib_imports)
         sh.instantiate(_mx_metashade_rotate_vector3)
 
         surfaceshader_nodedef = stdlib_doc.getNodeDef(_SURFACESHADER_NODEDEF)
@@ -555,16 +561,14 @@ _SCATTER_R = 0
 _SCATTER_T = 1
 _DISTRIBUTION_GGX = 0
 
-_STDLIB_IMPORTS = (
+_BASE_STDLIB_IMPORTS = frozenset({
     "roughness_anisotropy",
     "oren_nayar_diffuse_bsdf",
-    "translucent_bsdf",
-    "subsurface_bsdf",
     "sheen_bsdf",
     "dielectric_bsdf",
     "conductor_bsdf",
     "artistic_ior",
-)
+})
 
 _BSDF_INPUTS = frozenset({
     "base", "base_color", "diffuse_roughness",
@@ -596,13 +600,7 @@ def _find_genglsl_impl(stdlib_doc, node_name):
 
 
 def _acquire_stdlib_sourcecode_nodes(sh, stdlib_doc, node_names):
-    """Resolve, include, and acquire stdlib sourcecode nodes.
-
-    *node_names* is an ordered sequence of MaterialX source-code node
-    names whose genglsl implementations will be included and acquired.
-    Order matters: dependencies must come before dependents so that
-    ``#include`` directives are emitted in the right order.
-    """
+    """Resolve, include, and acquire stdlib sourcecode nodes."""
     for name in node_names:
         impl = _find_genglsl_impl(stdlib_doc, name)
         assert impl is not None, (

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -1,11 +1,11 @@
-#include "mx_dielectric_bsdf.glsl"
-#include "mx_subsurface_bsdf.glsl"
-#include "mx_sheen_bsdf.glsl"
-#include "mx_translucent_bsdf.glsl"
-#include "mx_oren_nayar_diffuse_bsdf.glsl"
-#include "mx_roughness_anisotropy.glsl"
 #include "mx_artistic_ior.glsl"
 #include "mx_conductor_bsdf.glsl"
+#include "mx_dielectric_bsdf.glsl"
+#include "mx_oren_nayar_diffuse_bsdf.glsl"
+#include "mx_roughness_anisotropy.glsl"
+#include "mx_sheen_bsdf.glsl"
+#include "mx_subsurface_bsdf.glsl"
+#include "mx_translucent_bsdf.glsl"
 // Rodrigues' rotation formula.
 // 
 // Private copy of the stdlib rotate3d helper.  Avoids

--- a/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface/mx_metashade_standard_surface_bsdf_genglsl_impl.glsl
@@ -1,11 +1,11 @@
-#include "mx_roughness_anisotropy.glsl"
-#include "mx_oren_nayar_diffuse_bsdf.glsl"
-#include "mx_translucent_bsdf.glsl"
+#include "mx_dielectric_bsdf.glsl"
 #include "mx_subsurface_bsdf.glsl"
 #include "mx_sheen_bsdf.glsl"
-#include "mx_dielectric_bsdf.glsl"
-#include "mx_conductor_bsdf.glsl"
+#include "mx_translucent_bsdf.glsl"
+#include "mx_oren_nayar_diffuse_bsdf.glsl"
+#include "mx_roughness_anisotropy.glsl"
 #include "mx_artistic_ior.glsl"
+#include "mx_conductor_bsdf.glsl"
 // Rodrigues' rotation formula.
 // 
 // Private copy of the stdlib rotate3d helper.  Avoids

--- a/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_bsdf_genglsl_impl.glsl
@@ -1,9 +1,9 @@
-#include "mx_dielectric_bsdf.glsl"
-#include "mx_sheen_bsdf.glsl"
-#include "mx_oren_nayar_diffuse_bsdf.glsl"
-#include "mx_roughness_anisotropy.glsl"
 #include "mx_artistic_ior.glsl"
 #include "mx_conductor_bsdf.glsl"
+#include "mx_dielectric_bsdf.glsl"
+#include "mx_oren_nayar_diffuse_bsdf.glsl"
+#include "mx_roughness_anisotropy.glsl"
+#include "mx_sheen_bsdf.glsl"
 // Rodrigues' rotation formula.
 // 
 // Private copy of the stdlib rotate3d helper.  Avoids

--- a/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_bsdf_genglsl_impl.glsl
@@ -1,11 +1,9 @@
-#include "mx_roughness_anisotropy.glsl"
-#include "mx_oren_nayar_diffuse_bsdf.glsl"
-#include "mx_translucent_bsdf.glsl"
-#include "mx_subsurface_bsdf.glsl"
-#include "mx_sheen_bsdf.glsl"
 #include "mx_dielectric_bsdf.glsl"
-#include "mx_conductor_bsdf.glsl"
+#include "mx_sheen_bsdf.glsl"
+#include "mx_oren_nayar_diffuse_bsdf.glsl"
+#include "mx_roughness_anisotropy.glsl"
 #include "mx_artistic_ior.glsl"
+#include "mx_conductor_bsdf.glsl"
 // Rodrigues' rotation formula.
 // 
 // Private copy of the stdlib rotate3d helper.  Avoids


### PR DESCRIPTION
Part of #233

## Summary

- Prune `#include` directives for disabled BSDF lobes in the generated GLSL source code
- Additive import model: base imports (always needed) plus frozenset union of enabled-lobe imports
- Refactor `_acquire_stdlib_sourcecode_nodes` to group by header file, deduplicate includes, and emit in sorted order for deterministic output

Subsurface-disabled permutation drops `mx_translucent_bsdf.glsl` and `mx_subsurface_bsdf.glsl`, yielding:
- **LOC**: -4.1% (67 lines per material)
- **SPIR-V size**: -6.2% (~8.4 KB per material)
- **Optimized SPIR-V**: -2.7%

## Test plan

- [x] `test_generate[full]` and `test_generate[subsurface0]` pass
- [x] Refs are idempotent across runs (deterministic sorted includes)
- [x] MaterialX render tests: 18/21 FLIP-matched (remaining are missing baselines, not regressions)