### PR TITLE
Prune disabled-lobe inputs from BSDF signature and nodegraph

### DIFF
--- a/metashade/mtlx/standard_surface.py
+++ b/metashade/mtlx/standard_surface.py
@@ -113,6 +113,14 @@ class Permutation:
         return "_" + "_".join(f"{d}0" for d in disabled)
 
     @property
+    def pruned_params(self) -> frozenset[str]:
+        """BSDF parameters removed from the signature for disabled lobes."""
+        return frozenset().union(*(
+            lobe.params for lobe in LOBES
+            if not getattr(self, lobe.name)
+        ))
+
+    @property
     def func_name(self) -> str:
         """Full function name for the generated BSDF node."""
         return _FUNC_NAME_BASE + self.variant_suffix + _FUNC_NAME_TYPE
@@ -161,7 +169,7 @@ class Permutation:
         assert surfaceshader_nodedef is not None, (
             f"Could not find {_SURFACESHADER_NODEDEF}"
         )
-        params = _build_bsdf_params(sh, surfaceshader_nodedef)
+        params = _build_bsdf_params(sh, surfaceshader_nodedef, self.pruned_params)
 
         with sh.function(self.func_name)(**params):
             sh // ""
@@ -511,10 +519,11 @@ class Permutation:
         ng = doc.addNodeGraph(self.nodegraph_name)
         ng.setNodeDefString(_SURFACESHADER_NODEDEF)
 
+        pruned = self.pruned_params
         bsdf_node = ng.addNode(self.bsdf_category, "std_surface", "BSDF")
         for inp in stock_nodedef.getActiveInputs():
             name = inp.getName()
-            if name not in _BSDF_INPUTS:
+            if name not in _BSDF_INPUTS or name in pruned:
                 continue
             bsdf_node.addInput(name, inp.getType()).setInterfaceName(name)
 
@@ -616,7 +625,7 @@ def _acquire_stdlib_sourcecode_nodes(sh, stdlib_doc, node_names):
             acquire_function(sh, impl)
 
 
-def _build_bsdf_params(sh, surfaceshader_nodedef):
+def _build_bsdf_params(sh, surfaceshader_nodedef, pruned_params=frozenset()):
     """Build BSDF node params from a subset of the surfaceshader nodedef inputs.
 
     Types are derived from the surfaceshader nodedef so that
@@ -628,7 +637,7 @@ def _build_bsdf_params(sh, surfaceshader_nodedef):
 
     for inp in surfaceshader_nodedef.getActiveInputs():
         name = inp.getName()
-        if name not in _BSDF_INPUTS:
+        if name not in _BSDF_INPUTS or name in pruned_params:
             continue
         dtype = mtlx_to_metashade_dtype(inp.getType(), sh)
         assert dtype is not None, (

--- a/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_bsdf_defs.mtlx
+++ b/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_bsdf_defs.mtlx
@@ -14,11 +14,6 @@
     <input name="transmission" type="float" doc="Input parameter transmission" />
     <input name="transmission_color" type="color3" doc="Input parameter transmission_color" />
     <input name="transmission_extra_roughness" type="float" doc="Input parameter transmission_extra_roughness" />
-    <input name="subsurface" type="float" doc="Input parameter subsurface" />
-    <input name="subsurface_color" type="color3" doc="Input parameter subsurface_color" />
-    <input name="subsurface_radius" type="color3" doc="Input parameter subsurface_radius" />
-    <input name="subsurface_scale" type="float" doc="Input parameter subsurface_scale" />
-    <input name="subsurface_anisotropy" type="float" doc="Input parameter subsurface_anisotropy" />
     <input name="sheen" type="float" doc="Input parameter sheen" />
     <input name="sheen_color" type="color3" doc="Input parameter sheen_color" />
     <input name="sheen_roughness" type="float" doc="Input parameter sheen_roughness" />
@@ -33,7 +28,6 @@
     <input name="coat_affect_roughness" type="float" doc="Input parameter coat_affect_roughness" />
     <input name="thin_film_thickness" type="float" doc="Input parameter thin_film_thickness" />
     <input name="thin_film_IOR" type="float" doc="Input parameter thin_film_IOR" />
-    <input name="thin_walled" type="boolean" doc="Input parameter thin_walled" />
     <input name="normal" type="vector3" doc="Input parameter normal" />
     <input name="tangent" type="vector3" doc="Input parameter tangent" />
     <output name="bsdf" type="BSDF" doc="Output parameter bsdf" />

--- a/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_bsdf_genglsl_impl.glsl
+++ b/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_bsdf_genglsl_impl.glsl
@@ -21,7 +21,7 @@ void _mx_metashade_rotate_vector3(vec3 in_, float amount, vec3 axis, out vec3 re
 	result = ((in_ * c) + (cross(in_, axis_n) * s)) + ((axis_n * dot(axis_n, in_)) * (1 - c));
 }
 
-void mx_metashade_standard_surface_subsurface0_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, bool thin_walled, vec3 normal, vec3 tangent, inout BSDF bsdf)
+void mx_metashade_standard_surface_subsurface0_bsdf(ClosureData closureData, float base, vec3 base_color, float diffuse_roughness, float metalness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float transmission, vec3 transmission_color, float transmission_extra_roughness, float sheen, vec3 sheen_color, float sheen_roughness, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, vec3 normal, vec3 tangent, inout BSDF bsdf)
 {
 	// 
 	// Coat affect roughness: blend specular roughness toward 1.0

--- a/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_surfaceshader.mtlx
+++ b/tests/ref/mtlx/standard_surface_pruned/mx_metashade_standard_surface_subsurface0_surfaceshader.mtlx
@@ -15,11 +15,6 @@
       <input name="transmission" type="float" interfacename="transmission" />
       <input name="transmission_color" type="color3" interfacename="transmission_color" />
       <input name="transmission_extra_roughness" type="float" interfacename="transmission_extra_roughness" />
-      <input name="subsurface" type="float" interfacename="subsurface" />
-      <input name="subsurface_color" type="color3" interfacename="subsurface_color" />
-      <input name="subsurface_radius" type="color3" interfacename="subsurface_radius" />
-      <input name="subsurface_scale" type="float" interfacename="subsurface_scale" />
-      <input name="subsurface_anisotropy" type="float" interfacename="subsurface_anisotropy" />
       <input name="sheen" type="float" interfacename="sheen" />
       <input name="sheen_color" type="color3" interfacename="sheen_color" />
       <input name="sheen_roughness" type="float" interfacename="sheen_roughness" />
@@ -34,7 +29,6 @@
       <input name="coat_affect_roughness" type="float" interfacename="coat_affect_roughness" />
       <input name="thin_film_thickness" type="float" interfacename="thin_film_thickness" />
       <input name="thin_film_IOR" type="float" interfacename="thin_film_IOR" />
-      <input name="thin_walled" type="boolean" interfacename="thin_walled" />
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" interfacename="tangent" />
     </metashade_standard_surface_subsurface0_bsdf>


### PR DESCRIPTION
## Summary

Adds parameter pruning for disabled lobes: when a lobe is off (e.g. `subsurface=False`), its parameters are excluded from the generated BSDF function signature, nodedef, and surfaceshader nodegraph wiring.

### Changes

- **`Permutation.pruned_params`** property: collects parameter names owned by disabled lobes
- **`_build_bsdf_params()`**: new `pruned_params` kwarg to filter the BSDF function signature
- **`generate_surfaceshader_nodegraph()`**: filters pruned params from nodegraph wiring

### Result for `subsurface=False`

6 parameters pruned from all generated artifacts:
`subsurface`, `subsurface_color`, `subsurface_radius`, `subsurface_scale`, `subsurface_anisotropy`, `thin_walled`

### Validation

- 222 metashade unit tests pass
- MaterialX render comparison tests pass (shader gen): full SS (25), pruned (21/37 subtests), adsk (52/140 subtests)

WIP towards #233